### PR TITLE
Fix window title typo

### DIFF
--- a/src/window/window.c
+++ b/src/window/window.c
@@ -66,7 +66,7 @@ int powergl_window_create(powergl_window *wnd, int width, int height) {
 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4);
         //Create window
-        wnd->window = SDL_CreateWindow("PoweGL Engine", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+        wnd->window = SDL_CreateWindow("PowerGL Engine", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
 
         if(wnd->window == NULL) {
             printf("Window could not be created! SDL Error: %s\n", SDL_GetError());


### PR DESCRIPTION
## Summary
- fix typo in `powergl_window_create` window title
- verify compile after fix

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc) > /tmp/make.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_684c5833c448832287e4a53bcdd0a869