### PR TITLE
Add cross-platform CMake build and timing fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.10)
+project(PowerGL C)
+
+set(CMAKE_C_STANDARD 99)
+
+# Dependencies
+find_package(OpenGL REQUIRED)
+find_package(PNG REQUIRED)
+find_package(SDL2 REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(EXPAT REQUIRED)
+
+include_directories(${SDL2_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS})
+
+add_library(powergl
+    src/powergl.c
+    src/window/window.c
+    src/rendering/object.c
+    src/rendering/pipeline.c
+    src/rendering/visualscene.c
+    src/rendering/dae2object.c
+    src/rendering/objectlibrary.c
+    src/rendering/3dtext.c
+    src/math/mat4x4.c
+    src/math/vec3.c
+    src/math/intersect.c
+    src/collada/importer.c
+    src/collada/exporter.c
+    src/collada/dom_connector.c
+    src/collada/parse_utils.c
+    src/collada/core/core.c
+    src/png/png_loader.c
+)
+
+target_link_libraries(powergl PUBLIC
+    ${SDL2_LIBRARIES}
+    ${OPENGL_gl_LIBRARY}
+    ${GLEW_LIBRARIES}
+    ${PNG_LIBRARIES}
+    ${EXPAT_LIBRARIES}
+)
+
+target_include_directories(powergl PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+)
+

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -110,14 +110,13 @@ int powergl_window_run(powergl_window *wnd) {
     int quit = 0;
     SDL_Event e;
 
-    struct timespec ts1; // both C11 and POSIX
-    struct timespec ts2;
-    clock_gettime(CLOCK_REALTIME, &ts1); // POSIX
+    Uint64 last_counter = SDL_GetPerformanceCounter();
+    Uint64 frequency = SDL_GetPerformanceFrequency();
 
 
     while(!quit) {
-      	clock_gettime(CLOCK_REALTIME, &ts2);	
-	delta_time = ts2.tv_sec + 1e-9*ts2.tv_nsec - (ts1.tv_sec + 1e-9*ts1.tv_nsec);
+        Uint64 current_counter = SDL_GetPerformanceCounter();
+        delta_time = (float)(current_counter - last_counter) / (float)frequency;
 	
         while(SDL_PollEvent(&e) != 0) {
 	  wnd->root_scene->handle_events(wnd->root_scene, &e, delta_time);
@@ -134,7 +133,7 @@ int powergl_window_run(powergl_window *wnd) {
         //Update screen
         SDL_GL_SwapWindow(wnd->window);
 
-	ts1 = ts2;
+        last_counter = current_counter;
     }
 
 


### PR DESCRIPTION
## Summary
- add a new cross-platform `CMakeLists.txt`
- replace `clock_gettime` usage with SDL timing functions

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684c598e6dc48322a5c746c87a655973