### PR TITLE
Fix color attribute pointer

### DIFF
--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -350,7 +350,7 @@ void powergl_pipeline_create_objects(powergl_pipeline *ppl, powergl_object **obj
       glVertexAttribPointer( ppl->nis.index, ppl->nis.size, ppl->nis.type, ppl->nis.normalized, ppl->nis.stride, ppl->nis.offset );
 
       glBindBuffer( GL_ARRAY_BUFFER, objs[i]->geometry.cbo );
-      glVertexAttribPointer( ppl->nis.index, ppl->nis.size, ppl->nis.type, ppl->nis.normalized, ppl->nis.stride, ppl->nis.offset );
+      glVertexAttribPointer( ppl->cis.index, ppl->cis.size, ppl->cis.type, ppl->cis.normalized, ppl->cis.stride, ppl->cis.offset );
 
       glBindBuffer( GL_ARRAY_BUFFER, objs[i]->geometry.tcbo );
       glVertexAttribPointer( ppl->tcis.index, ppl->tcis.size, ppl->tcis.type, ppl->tcis.normalized, ppl->tcis.stride, ppl->tcis.offset );


### PR DESCRIPTION
## Summary
- fix glVertexAttribPointer call for color buffer to use color attribute settings

## Testing
- `cmake .. && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684db7b74ae08322a228546a1d094b85