### PR TITLE
Remove googletest submodule

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,8 +21,8 @@ jobs:
       run: sudo apt-get install libexpat1-dev
     - name: png setup
       run: sudo apt-get install libpng-dev
-    - name: Init submodules
-      run: git submodule update --init --recursive    
+    - name: gtest setup
+      run: sudo apt-get install libgtest-dev
     - name: autoreconf
       run: autoreconf -iv
     - name: configure

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "googletest"]
-	path = googletest
-	url = https://github.com/google/googletest.git

--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@ PowerGL is a graphics engine implemented with C using OpenGL
 
 
 ## Running Tests
-After cloning, initialize submodules:
-```sh
-git submodule update --init
-```
-Generate build files and run the test suite:
+Install the Google Test development package (for example `libgtest-dev` on
+Debian/Ubuntu) and then generate build files and run the test suite:
 ```sh
 autoreconf -i
 ./configure

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects])
 LT_PREREQ([2.4.6])
 LT_INIT
 AM_PROG_AR
+PKG_PROG_PKG_CONFIG
 
 # Checks for programs.
 AC_PROG_CXX
@@ -29,6 +30,9 @@ AC_CHECK_LIB([expat], [XML_Parse])
 AC_CHECK_LIB([SDL2], [SDL_Init])
 AC_CHECK_LIB([GLEW], [glewInit])
 AC_CHECK_LIB([png16], [png_read_image])
+
+# Check for Google Test using pkg-config
+PKG_CHECK_MODULES([GTEST], [gtest_main], [], [AC_MSG_ERROR([Google Test not found])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([stddef.h stdlib.h string.h])

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -13,6 +13,7 @@ PACKAGES=(
   libsdl2-dev
   libglew-dev
   libpng-dev
+  libgtest-dev
 )
 
 if [ "$EUID" -ne 0 ]; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,18 +1,14 @@
 # Automake file for unit tests
 AM_CPPFLAGS = \
-    -I$(top_srcdir)/src \
-    -I$(top_srcdir)/googletest/googletest \
-    -I$(top_srcdir)/googletest/googletest/include
+    -I$(top_srcdir) \
+    $(GTEST_CFLAGS)
 AM_CXXFLAGS = -std=c++17
-
-check_LTLIBRARIES = libgtest.la
-libgtest_la_SOURCES = $(top_srcdir)/googletest/googletest/src/gtest-all.cc
 
 check_PROGRAMS = gtest_mat4_inv
 TESTS = $(check_PROGRAMS)
 
 gtest_mat4_inv_SOURCES = gtest_mat4_inv.cpp
 
-gtest_mat4_inv_LDADD = libgtest.la $(top_builddir)/src/math/libpowerglmath.la -lm
+gtest_mat4_inv_LDADD = $(top_builddir)/src/math/libpowerglmath.la $(GTEST_LIBS) -lm
 
 # Run tests via make check


### PR DESCRIPTION
## Summary
- remove obsolete googletest submodule
- look for gtest with pkg-config in `configure.ac`
- link tests against system gtest
- install gtest in CI and dependency script
- document new dependency

## Testing
- `autoreconf -iv`
- `./configure`
- `make`
- `make check`
- `make distcheck`


------
https://chatgpt.com/codex/tasks/task_e_684f1dc2dd308322aa13710ff060275d