### PR TITLE
Integrate gcovr for coverage report

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,10 +26,20 @@ jobs:
     - name: autoreconf
       run: autoreconf -iv
     - name: configure
-      run: ./configure
+      run: CFLAGS="--coverage" CXXFLAGS="--coverage" LDFLAGS="--coverage" ./configure
     - name: make
       run: make
     - name: make check
       run: make check
+    - name: install gcovr
+      run: sudo apt-get install gcovr
+    - name: gcovr
+      run: |
+        mkdir -p coverage
+        gcovr -r . --xml-pretty -o coverage/coverage.xml
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage
     - name: make distcheck
       run: make distcheck

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         mkdir -p coverage
         gcovr -r . --xml-pretty -o coverage/coverage.xml
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -36,7 +36,7 @@ jobs:
     - name: gcovr
       run: |
         mkdir -p coverage
-        gcovr -r . --xml-pretty -o coverage/coverage.xml
+        gcovr -r . --xml-pretty -o coverage/coverage.xml --gcov-ignore-errors no_working_dir_found
     - uses: actions/upload-artifact@v4
       with:
         name: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 autom4te.cache
+
+# coverage reports
+coverage/
+

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ Install gcovr via apt:
 sudo apt-get install gcovr
 ```
 ```sh
-gcovr -r . --html --html-details -o coverage/index.html
+gcovr -r . --html --html-details -o coverage/index.html --gcov-ignore-errors no_working_dir_found
 ```

--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ autoreconf -i
 ./configure
 make check
 ```
+
+## Coverage
+After running the tests you can generate coverage reports using [gcovr](https://gcovr.com/):
+Install gcovr via apt:
+```sh
+sudo apt-get install gcovr
+```
+```sh
+gcovr -r . --html --html-details -o coverage/index.html
+```


### PR DESCRIPTION
## Summary
- ignore coverage dir
- explain how to generate coverage report
- produce coverage artifact in CI workflow
- keep coverage folder in repo
- install gcovr using apt

## Testing
- `sudo ./install_dependencies.sh`
- `autoreconf -iv`
- `CFLAGS="--coverage" CXXFLAGS="--coverage" LDFLAGS="--coverage" ./configure`
- `make`
- `make check`
- `gcovr -r . --xml-pretty -o coverage/coverage.xml --gcov-ignore-errors no_working_dir_found`
- `make distcheck`


------
https://chatgpt.com/codex/tasks/task_e_684f240fded48322b416ea71ebac3772