### PR TITLE
Fix segfault when resolving COLLADA references

### DIFF
--- a/src/collada/importer.c
+++ b/src/collada/importer.c
@@ -317,12 +317,14 @@ static size_t resolve_pending_references(dom_connector *root){
         dom_connector *target = resolve_uri(uri);
         if(target){
             dom_connector *parent = ref->parent;
-            for(size_t l=0;l<parent->n_map;++l){
-                for(size_t m=0;m<parent->nodes[l].n_node;++m){
+            int done = 0;
+            for(size_t l = 0; l < parent->n_map && !done; ++l){
+                for(size_t m = 0; m < parent->nodes[l].n_node; ++m){
                     if(parent->nodes[l].nodes[m] == ref){
                         parent->set_ref(parent, l, target);
                         resolved++;
-                        m=parent->nodes[l].n_node; l=parent->n_map;
+                        done = 1;
+                        break;
                     }
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,7 +27,7 @@ clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
 
 # Test data files shipped with the distribution
-EXTRA_DIST = cube.dae cube_exported.dae
+EXTRA_DIST = cube.dae
 
 # Remove generated files produced during tests
 CLEANFILES = cube_exported.dae exported.dae

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,8 @@
 AM_CPPFLAGS = \
     -I$(top_srcdir) \
     $(GTEST_CFLAGS) \
-    $(CODE_COVERAGE_CPPFLAGS)
+    $(CODE_COVERAGE_CPPFLAGS) \
+    -DTEST_SRCDIR=\"$(srcdir)\"
 AM_CXXFLAGS = -std=c++17 $(CODE_COVERAGE_CXXFLAGS)
 AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
@@ -24,5 +25,11 @@ include $(top_srcdir)/aminclude_static.am
 
 clean-local: code-coverage-clean
 distclean-local: code-coverage-dist-clean
+
+# Test data files shipped with the distribution
+EXTRA_DIST = cube.dae cube_exported.dae
+
+# Remove generated files produced during tests
+CLEANFILES = cube_exported.dae exported.dae
 
 # Run tests via make check

--- a/tests/gtest_collada.cpp
+++ b/tests/gtest_collada.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <string>
 extern "C" {
 #define this this_ptr
 #include "src/collada/importer.h"
@@ -6,8 +7,9 @@ extern "C" {
 #undef this
 }
 
-static powergl_collada_core_COLLADA* load_dae(const char* path){
-    dom_connector* root = powergl_collada_parse(path);
+static powergl_collada_core_COLLADA* load_dae(const char* file){
+    std::string path = std::string(TEST_SRCDIR) + "/" + file;
+    dom_connector* root = powergl_collada_parse(path.c_str());
     return (powergl_collada_core_COLLADA*)root;
 }
 


### PR DESCRIPTION
## Summary
- avoid accessing arrays out of bounds when resolving pending references without using `goto`

## Testing
- `autoreconf -i`
- `./configure`
- `make check -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684fc6fef07c8322add98e2d393ad900