### PR TITLE
Add rendering demo

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,6 +9,7 @@ AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
 
 check_PROGRAMS = gtest_math gtest_collada
+noinst_PROGRAMS = demo_cube
 TESTS = $(check_PROGRAMS)
 
 gtest_math_SOURCES = gtest_math.cpp
@@ -20,6 +21,10 @@ gtest_collada_LDADD = \
     $(top_builddir)/src/collada/libpowerglcollada.la \
     $(top_builddir)/src/libpowergl.la \
     $(GTEST_LIBS) -lm $(CODE_COVERAGE_LIBS)
+
+demo_cube_SOURCES = demo_cube.c
+demo_cube_LDADD = \
+    $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/tests/demo_cube.c
+++ b/tests/demo_cube.c
@@ -1,0 +1,51 @@
+#include <SDL2/SDL.h>
+#include "src/window/window.h"
+#include "src/rendering/visualscene.h"
+#include "src/rendering/object.h"
+#include "src/rendering/pipeline.h"
+
+static powergl_object *cube;
+static powergl_object *cube_list[1];
+
+static void scene_create(powergl_visualscene *scene){
+    const char *dae = TEST_SRCDIR "/cube.dae";
+    powergl_scene_build(scene, dae);
+    scene->main_camera = powergl_scene_find(scene, "Camera");
+    scene->main_light = powergl_scene_find(scene, "Light");
+    cube = powergl_scene_find(scene, "Cube");
+    cube_list[0] = cube;
+    if(scene->main_camera)
+        scene->main_camera->event_flag = 1;
+    powergl_pipeline_create(&scene->pipeline, cube_list, 1);
+}
+
+static void scene_events(powergl_visualscene *scene, SDL_Event *e, float dt){
+    if(scene->main_camera)
+        powergl_event_handle(scene->main_camera, e, dt);
+}
+
+static void scene_run(powergl_visualscene *scene, float dt){
+    if(scene->main_camera){
+        powergl_object_fps_controller(scene->main_camera, dt);
+        powergl_object_update_transform(scene->main_camera, dt);
+        powergl_camera_update(scene->main_camera);
+    }
+    if(cube && scene->main_camera){
+        powergl_object_update_mvp(cube, scene->main_camera);
+    }
+    if(cube){
+        powergl_pipeline_render(&scene->pipeline, cube_list, 1, scene->main_light);
+    }
+}
+
+int main(){
+    powergl_visualscene scene = {0};
+    scene.create = scene_create;
+    scene.run = scene_run;
+    scene.handle_events = scene_events;
+
+    powergl_window *wnd = powergl_window_new(&scene);
+    if(!powergl_window_create(wnd, 640, 480))
+        return 1;
+    return powergl_window_run(wnd);
+}


### PR DESCRIPTION
## Summary
- add a demo program rendering the cube DAE
- compile demo_cube via Automake

## Testing
- `autoreconf -fi`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68501788e8a08322bbd11887319bc45a