### PR TITLE
Add default camera helper

### DIFF
--- a/src/rendering/object.c
+++ b/src/rendering/object.c
@@ -482,3 +482,35 @@ void powergl_object_geometry_reset(powergl_geometry *geo){
   }
 
 }
+
+powergl_object *powergl_camera_default(){
+  powergl_object *cam = powergl_resize(NULL, 1, sizeof(powergl_object));
+  memset(cam, 0, sizeof(powergl_object));
+
+  cam->camera.type = 'p';
+  cam->camera.aspect_ratio = 1.0f;
+  cam->camera.yfov = powergl_float_to_radians(60.0f);
+  cam->camera.xfov = 0.0f;
+  cam->camera.znear = 0.1f;
+  cam->camera.zfar = 1000.0f;
+
+  cam->camera.view = powergl_mat4_lookatRH((powergl_vec3){0.0f,0.0f,10.0f},
+                                           (powergl_vec3){0.0f,0.0f,0.0f},
+                                           (powergl_vec3){0.0f,1.0f,0.0f});
+  cam->camera.view_flag = 1;
+
+  cam->camera.projection = powergl_mat4_perspectiveRH(cam->camera.yfov,
+                                                      cam->camera.aspect_ratio,
+                                                      cam->camera.znear,
+                                                      cam->camera.zfar);
+  cam->camera.projection_flag = 1;
+
+  cam->camera.vp = powergl_mat4_mul(cam->camera.projection, cam->camera.view);
+  cam->camera.vp_flag = 1;
+
+  powergl_transform_reset(&cam->transform);
+  cam->transform.location = (powergl_vec3){0.0f,0.0f,10.0f};
+  cam->camera_flag = 1;
+
+  return cam;
+}

--- a/src/rendering/object.h
+++ b/src/rendering/object.h
@@ -238,6 +238,13 @@ void powergl_object_geometry_reset(powergl_geometry *geo);
 
 void powergl_transform_reset(powergl_transform *trans);
 
+/* Creates and returns a camera object with default parameters.
+   - field of view: 60 degrees
+   - near plane: 0.1
+   - far plane: 1000
+   - positioned at (0,0,10) looking at the origin */
+powergl_object *powergl_camera_default();
+
  
 
 

--- a/tests/demo_cube.c
+++ b/tests/demo_cube.c
@@ -11,6 +11,8 @@ static void scene_create(powergl_visualscene *scene){
     const char *dae = TEST_SRCDIR "/cube.dae";
     powergl_scene_build(scene, dae);
     scene->main_camera = powergl_scene_find(scene, "Camera");
+    if(!scene->main_camera)
+        scene->main_camera = powergl_camera_default();
     scene->main_light = powergl_scene_find(scene, "Light");
     cube = powergl_scene_find(scene, "Cube");
     cube_list[0] = cube;


### PR DESCRIPTION
## Summary
- add `powergl_camera_default` to create a camera with common defaults
- use the new helper in `demo_cube` when no camera exists

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6851600eeed48322a2ebb2477f32d936