### PR TITLE
Add EGL headless backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,14 @@ find_package(PNG REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(EXPAT REQUIRED)
+find_package(EGL REQUIRED)
 
 include_directories(${SDL2_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS})
 
 add_library(powergl
     src/powergl.c
     src/window/window.c
+    src/window/headless.c
     src/rendering/object.c
     src/rendering/pipeline.c
     src/rendering/visualscene.c
@@ -36,6 +38,7 @@ target_link_libraries(powergl PUBLIC
     ${SDL2_LIBRARIES}
     ${OPENGL_gl_LIBRARY}
     ${GLEW_LIBRARIES}
+    ${EGL_LIBRARIES}
     ${PNG_LIBRARIES}
     ${EXPAT_LIBRARIES}
 )

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ AC_CHECK_LIB([X11], [XFree])
 AC_CHECK_LIB([expat], [XML_Parse])
 AC_CHECK_LIB([SDL2], [SDL_Init])
 AC_CHECK_LIB([GLEW], [glewInit])
+AC_CHECK_LIB([EGL], [eglGetDisplay])
 AC_CHECK_LIB([png16], [png_read_image])
 
 # Check for Google Test using pkg-config

--- a/src/window/Makefile.am
+++ b/src/window/Makefile.am
@@ -3,11 +3,13 @@ AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 noinst_LTLIBRARIES = libpowerglwindow.la
 libpowerglwindow_ladir = $(includedir)/powergl/window
 libpowerglwindow_la_HEADERS = \
-	window.h
+        window.h \
+        headless.h
 libpowerglwindow_la_LDFLAGS = -no-undefined
 libpowerglwindow_la_SOURCES = \
-        window.c
-libpowerglwindow_la_LIBADD = $(CODE_COVERAGE_LIBS)
+        window.c \
+        headless.c
+libpowerglwindow_la_LIBADD = $(CODE_COVERAGE_LIBS) -lEGL
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/src/window/headless.c
+++ b/src/window/headless.c
@@ -1,0 +1,85 @@
+#include "headless.h"
+#include <string.h>
+#include <stdio.h>
+
+static const EGLint configAttribs[] = {
+    EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+    EGL_BLUE_SIZE, 8,
+    EGL_GREEN_SIZE, 8,
+    EGL_RED_SIZE, 8,
+    EGL_DEPTH_SIZE, 8,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+    EGL_NONE
+};
+
+powergl_headless *powergl_headless_new(powergl_visualscene *scene){
+    powergl_headless *h = calloc(1, sizeof(*h));
+    h->root_scene = scene;
+    return h;
+}
+
+int powergl_headless_create(powergl_headless *h, int width, int height){
+    h->width = width;
+    h->height = height;
+
+    h->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if(h->display == EGL_NO_DISPLAY){
+        fprintf(stderr, "Failed to get EGL display\n");
+        return 0;
+    }
+
+    if(!eglInitialize(h->display, NULL, NULL)){
+        fprintf(stderr, "Failed to initialize EGL\n");
+        return 0;
+    }
+
+    EGLint numConfigs;
+    EGLConfig eglCfg;
+    if(!eglChooseConfig(h->display, configAttribs, &eglCfg, 1, &numConfigs)){
+        fprintf(stderr, "Failed to choose EGL config\n");
+        return 0;
+    }
+
+    const EGLint pbufferAttribs[] = {
+        EGL_WIDTH, width,
+        EGL_HEIGHT, height,
+        EGL_NONE,
+    };
+
+    h->surface = eglCreatePbufferSurface(h->display, eglCfg, pbufferAttribs);
+    if(h->surface == EGL_NO_SURFACE){
+        fprintf(stderr, "Failed to create EGL surface\n");
+        return 0;
+    }
+
+    if(!eglBindAPI(EGL_OPENGL_API)){
+        fprintf(stderr, "Failed to bind OpenGL API\n");
+        return 0;
+    }
+
+    h->context = eglCreateContext(h->display, eglCfg, EGL_NO_CONTEXT, NULL);
+    if(h->context == EGL_NO_CONTEXT){
+        fprintf(stderr, "Failed to create EGL context\n");
+        return 0;
+    }
+
+    if(!eglMakeCurrent(h->display, h->surface, h->surface, h->context)){
+        fprintf(stderr, "Failed to make EGL context current\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+int powergl_headless_run(powergl_headless *h){
+    if(h->root_scene){
+        h->root_scene->create(h->root_scene);
+        h->root_scene->run(h->root_scene, 0.0f);
+    }
+    eglSwapBuffers(h->display, h->surface);
+    eglMakeCurrent(h->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglDestroySurface(h->display, h->surface);
+    eglDestroyContext(h->display, h->context);
+    eglTerminate(h->display);
+    return 0;
+}

--- a/src/window/headless.h
+++ b/src/window/headless.h
@@ -1,0 +1,23 @@
+#ifndef _powergl_headless_h
+#define _powergl_headless_h
+
+#include <EGL/egl.h>
+#include "../powergl.h"
+#include "../rendering/visualscene.h"
+
+typedef struct powergl_headless_t powergl_headless;
+
+struct powergl_headless_t {
+    powergl_visualscene *root_scene;
+    EGLDisplay display;
+    EGLSurface surface;
+    EGLContext context;
+    int width;
+    int height;
+};
+
+powergl_headless *powergl_headless_new(powergl_visualscene *scene);
+int powergl_headless_create(powergl_headless *h, int width, int height);
+int powergl_headless_run(powergl_headless *h);
+
+#endif

--- a/tests/demo_cube.c
+++ b/tests/demo_cube.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "src/window/window.h"
+#include "src/window/headless.h"
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/pipeline.h"
@@ -155,8 +156,16 @@ int main(){
     scene.run = scene_run;
     scene.handle_events = scene_events;
 
-    powergl_window *wnd = powergl_window_new(&scene);
-    if(!powergl_window_create(wnd, 640, 480))
-        return 1;
-    return powergl_window_run(wnd);
+    const char *headless = getenv("POWERGL_HEADLESS");
+    if(headless && strcmp(headless, "1") == 0){
+        powergl_headless *h = powergl_headless_new(&scene);
+        if(!powergl_headless_create(h, 640, 480))
+            return 1;
+        return powergl_headless_run(h);
+    } else {
+        powergl_window *wnd = powergl_window_new(&scene);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+        return powergl_window_run(wnd);
+    }
 }


### PR DESCRIPTION
## Summary
- support headless rendering using EGL
- link with EGL in build scripts
- add environment flag in demo to use headless backend

## Testing
- `autoreconf -i`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6852afdbd14083228df1cd620303aeb6