### PR TITLE
Add headless configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,26 @@ sudo apt-get install gcovr
 ```sh
 gcovr -r . --html --html-details -o coverage/index.html --gcov-ignore-errors no_working_dir_found
 ```
+
+## Headless Configuration
+PowerGL can render scenes without opening an on-screen window by using its
+headless backend based on EGL. This is useful for automated tests or systems
+without a graphical environment.
+
+Install the Mesa EGL development package if it is not already present. On
+Debian/Ubuntu you can do this with:
+
+```sh
+sudo apt-get install libegl1-mesa-dev
+```
+
+To run the demo cube example in headless mode, set the environment variable
+`POWERGL_HEADLESS` to `1` before executing the program:
+
+```sh
+POWERGL_HEADLESS=1 ./tests/demo_cube
+```
+
+The headless backend creates an off-screen EGL context and renders frames to a
+pbuffer surface. The example saves these frames as PNG images so they can be
+inspected later without requiring a display.

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -8,6 +8,7 @@ PACKAGES=(
   pkg-config
   build-essential
   libgl1-mesa-dev
+  libegl1-mesa-dev
   libx11-dev
   libexpat1-dev
   libsdl2-dev


### PR DESCRIPTION
## Summary
- document how to run PowerGL in headless mode
- mention installing the Mesa EGL headers
- add libegl1-mesa-dev to install_dependencies.sh

## Testing
- `autoreconf -i`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6852b4de1d648322a9f4c76ec8d0fc6d