### PR TITLE
Make GL debug output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ POWERGL_HEADLESS=1 ./tests/demo_cube
 The headless backend creates an off-screen EGL context and renders frames to a
 pbuffer surface. The example saves these frames as PNG images so they can be
 inspected later without requiring a display.
+
+## OpenGL Debug Output
+PowerGL can register an OpenGL debug callback to print driver messages. Set
+the environment variable `POWERGL_GL_DEBUG` to `1` to enable it:
+
+```sh
+POWERGL_GL_DEBUG=1 ./tests/demo_cube
+```

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -98,10 +98,17 @@ int powergl_window_create(powergl_window *wnd, int width, int height) {
     return success;
 }
 
+static int gl_debug_enabled(void){
+    const char *env = getenv("POWERGL_GL_DEBUG");
+    return env && strcmp(env, "1") == 0;
+}
+
 int powergl_window_run(powergl_window *wnd) {
-    glDebugMessageCallback(errorCallback, NULL);
-    glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
-    glEnable(GL_DEBUG_OUTPUT);
+    if(gl_debug_enabled()) {
+        glDebugMessageCallback(errorCallback, NULL);
+        glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
+        glEnable(GL_DEBUG_OUTPUT);
+    }
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_MULTISAMPLE);
     glClearColor(0.3f, 0.6f, 0.9f, 1.0f);

--- a/tests/demo_cube.c
+++ b/tests/demo_cube.c
@@ -152,6 +152,7 @@ static void scene_run(powergl_visualscene *scene, float dt){
 
 int main(){
     powergl_visualscene scene = {0};
+    setenv("POWERGL_GL_DEBUG", "1", 0);
     scene.create = scene_create;
     scene.run = scene_run;
     scene.handle_events = scene_events;


### PR DESCRIPTION
## Summary
- optionally enable GL debug output via `POWERGL_GL_DEBUG`
- enable GL debug messages in `tests/demo_cube`
- document the debug variable in the README

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6853cf2b1df48322b0acf7756588448e