### PR TITLE
Fix Z_UP orientation

### DIFF
--- a/src/collada/importer.c
+++ b/src/collada/importer.c
@@ -424,4 +424,25 @@ dom_connector *powergl_collada_parse(const char *filename) {
     return g_root;
 }
 
+int powergl_collada_is_z_up(const char *filename){
+    FILE *f = fopen(filename, "r");
+    if(!f)
+        return 0;
+    char line[256];
+    int res = 0;
+    while(fgets(line, sizeof(line), f)){
+        char *p = strstr(line, "<up_axis>");
+        if(p){
+            char axis[16] = {0};
+            if(sscanf(p, "<up_axis>%15[^<]", axis) == 1){
+                if(strcmp(axis, "Z_UP") == 0)
+                    res = 1;
+            }
+            break;
+        }
+    }
+    fclose(f);
+    return res;
+}
+
 #undef DEBUG_OUTPUT

--- a/src/collada/importer.h
+++ b/src/collada/importer.h
@@ -13,5 +13,6 @@ extern dom_connector *g_root;
 dom_connector *powergl_collada_parse(const char *filename);
 void powergl_collada_export_dae_file(dom_connector *root, const char *file_name);
 void powergl_collada_delete_dom_connector(dom_connector *elemm, size_t depth);
+int powergl_collada_is_z_up(const char *filename);
 
 #endif

--- a/src/rendering/dae2object.c
+++ b/src/rendering/dae2object.c
@@ -4,6 +4,13 @@
 #define DEBUG_OUTPUT 1
 #endif
 
+static const powergl_mat4 POWERGL_ZUP_TO_YUP = { .c = {
+    {1.0f, 0.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, -1.0f, 0.0f},
+    {0.0f, 1.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 0.0f, 1.0f}
+}};
+
 typedef struct tokens_t {
   char **arr;
   size_t n;
@@ -595,7 +602,7 @@ void powergl_build_light(powergl_collada_core_node *node, powergl_object *obj) {
   }
 }
 
-void powergl_build_transform(powergl_collada_core_node *node, powergl_object *obj) {
+void powergl_build_transform(powergl_collada_core_node *node, powergl_object *obj, int axis_convert) {
 #if DEBUG_OUTPUT
   printf("\n%s\n", __func__);
 #endif
@@ -635,13 +642,14 @@ void powergl_build_transform(powergl_collada_core_node *node, powergl_object *ob
   }
 
   if(obj->parent != NULL){
-
     obj->transform.world = powergl_mat4_mul(obj->parent->transform.world, obj->transform.local);
-    
   } else {
-    
     obj->transform.world = powergl_mat4_ident();
-    
+  }
+
+  if(axis_convert && obj->parent == NULL){
+    obj->transform.local = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.local);
+    obj->transform.world = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.world);
   }
 
   obj->transform.matrix_flag = 1;
@@ -651,7 +659,7 @@ void powergl_build_transform(powergl_collada_core_node *node, powergl_object *ob
 #endif
 }
 
-void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core_COLLADA *root, powergl_object *obj) {
+void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core_COLLADA *root, powergl_object *obj, int axis_convert) {
 #if DEBUG_OUTPUT
   printf("\n%s -> %s\n", __func__, node->c_id);
 #endif
@@ -662,7 +670,7 @@ void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core
   }
 
   if(node->n_translate > 0 || node->n_rotate > 0) {
-    powergl_build_transform(node, obj);
+    powergl_build_transform(node, obj, axis_convert);
   } else if(node->n_matrix > 0) {
     powergl_mat4_copy(&obj->transform.local, node->c_matrix[0]->content,
                       node->c_matrix[0]->n_content, 1);
@@ -671,6 +679,10 @@ void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core
           powergl_mat4_mul(obj->parent->transform.world, obj->transform.local);
     } else {
       obj->transform.world = obj->transform.local;
+    }
+    if(axis_convert && obj->parent == NULL){
+      obj->transform.local = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.local);
+      obj->transform.world = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.world);
     }
     obj->transform.location.x = obj->transform.local.c[3].x;
     obj->transform.location.y = obj->transform.local.c[3].y;
@@ -709,8 +721,8 @@ void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core
       powergl_object *newobj = powergl_resize(NULL, 1, sizeof(powergl_object));
       newobj->parent = obj;
       obj->objects[i] = newobj;
-      
-      powergl_build_object(node->c_node[i], root, newobj);
+
+      powergl_build_object(node->c_node[i], root, newobj, 0);
     }
     
   }

--- a/src/rendering/dae2object.h
+++ b/src/rendering/dae2object.h
@@ -15,8 +15,8 @@ void powergl_build_animation(powergl_collada_core_library_animations *anim_lib, 
 void powergl_build_geometry(powergl_collada_core_node *node, powergl_object *obj);
 void powergl_build_camera(powergl_collada_core_node *node, powergl_object *obj);
 void powergl_build_light(powergl_collada_core_node *node, powergl_object *obj);
-void powergl_build_transform(powergl_collada_core_node *node, powergl_object *obj);
-void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core_COLLADA *root, powergl_object *obj);
+void powergl_build_transform(powergl_collada_core_node *node, powergl_object *obj, int axis_convert);
+void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core_COLLADA *root, powergl_object *obj, int axis_convert);
 
 
 #endif

--- a/src/rendering/objectlibrary.c
+++ b/src/rendering/objectlibrary.c
@@ -9,6 +9,7 @@ powergl_object_library * powergl_object_library_build(const char *file){
     printf("%s\n", __func__);
     printf("the dae file will be parsed = %s \n", file);
 #endif
+    int zup = powergl_collada_is_z_up(file);
     powergl_collada_core_COLLADA  *root = (powergl_collada_core_COLLADA *)powergl_collada_parse(file);
     powergl_collada_core_scene  *scene = root->c_scene[0];
     powergl_collada_core_InstanceWithExtra  *instance = scene->c_instance_visual_scene[0];
@@ -25,7 +26,7 @@ powergl_object_library * powergl_object_library_build(const char *file){
         lib->objects[i] = powergl_resize(NULL, 1, sizeof(powergl_object));
 	lib->objects[i]->parent = NULL;
 	
-        powergl_build_object(node, root, lib->objects[i]);
+        powergl_build_object(node, root, lib->objects[i], zup);
 
     } // for each node
 

--- a/src/rendering/visualscene.c
+++ b/src/rendering/visualscene.c
@@ -14,6 +14,7 @@ void powergl_scene_build(powergl_visualscene *this, const char *file) {
     printf("%s\n", __func__);
     printf("the dae file will be parsed = %s \n", file);
 #endif
+    int zup = powergl_collada_is_z_up(file);
     powergl_collada_core_COLLADA  *root = (powergl_collada_core_COLLADA *)powergl_collada_parse(file);
     powergl_collada_core_scene  *scene = root->c_scene[0];
     powergl_collada_core_InstanceWithExtra  *instance = scene->c_instance_visual_scene[0];
@@ -31,7 +32,7 @@ void powergl_scene_build(powergl_visualscene *this, const char *file) {
         this->objects[i] = powergl_resize(NULL, 1, sizeof(powergl_object));
 	this->objects[i]->parent = NULL;
 	
-        powergl_build_object(node, root, this->objects[i]);
+        powergl_build_object(node, root, this->objects[i], zup);
 
     } // for each node
 }

--- a/tests/gtest_collada.cpp
+++ b/tests/gtest_collada.cpp
@@ -4,6 +4,8 @@ extern "C" {
 #define this this_ptr
 #include "src/collada/importer.h"
 #include "src/collada/collada.h"
+#include "src/rendering/objectlibrary.h"
+#include "src/math/mat4x4.h"
 #undef this
 }
 
@@ -36,6 +38,24 @@ TEST(ColladaImporter, ExportRoundTrip){
                  root->c_library_cameras[0]->c_camera[0]->c_id);
     EXPECT_STREQ(exp->c_library_visual_scenes[0]->c_visual_scene[0]->c_node[2]->c_name,
                  root->c_library_visual_scenes[0]->c_visual_scene[0]->c_node[2]->c_name);
+}
+
+TEST(ObjectImport, AxisConversion){
+    std::string path = std::string(TEST_SRCDIR) + "/cube.dae";
+    powergl_object_library *lib = powergl_object_library_build(path.c_str());
+    ASSERT_NE(lib, nullptr);
+    powergl_object *cube = powergl_object_library_find_object(lib, "Cube");
+    ASSERT_NE(cube, nullptr);
+    powergl_vec4 v = {cube->geometry.vertex[0].x,
+                      cube->geometry.vertex[0].y,
+                      cube->geometry.vertex[0].z,
+                      1.0f};
+    powergl_mat4 w = cube->transform.world;
+    EXPECT_NEAR(w.c[0].x, 1.0f, 1e-5f);
+    EXPECT_NEAR(w.c[1].y, 0.0f, 1e-5f);
+    EXPECT_NEAR(w.c[1].z, -1.0f, 1e-5f);
+    EXPECT_NEAR(w.c[2].y, 1.0f, 1e-5f);
+    EXPECT_NEAR(w.c[2].z, 0.0f, 1e-5f);
 }
 
 int main(int argc, char **argv){


### PR DESCRIPTION
## Summary
- detect Z_UP orientation in collada importer
- rotate root transforms from Z_UP to Y_UP
- propagate corrected transforms through object hierarchy
- verify orientation fix with tests

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_685ef64967688322b42313627f3052b5