### PR TITLE
Fix distcheck test path

### DIFF
--- a/tests/run_vertexcoloredcube_headless.sh
+++ b/tests/run_vertexcoloredcube_headless.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
-POWERGL_HEADLESS=1 EGL_PLATFORM=surfaceless "$(dirname "$0")"/vertexcoloredcube_demo
+# Automake executes tests from their build directory, so the built
+# vertexcoloredcube_demo binary is available in the current working
+# directory.  Simply invoke it directly to work both in the build tree
+# and in "make distcheck".
+POWERGL_HEADLESS=1 EGL_PLATFORM=surfaceless ./vertexcoloredcube_demo


### PR DESCRIPTION
## Summary
- update vertexcoloredcube headless test to run from build dir

## Testing
- `make check`
- `make distcheck`


------
https://chatgpt.com/codex/tasks/task_e_6861a889db248322ae04c7f36929a29e