### PR TITLE
Ignore third party sources during coverage

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,7 +38,8 @@ jobs:
     - name: gcovr
       run: |
         mkdir -p coverage
-        gcovr -r . --html-details -o coverage/coverage.html --gcov-ignore-errors no_working_dir_found
+        gcovr -r . --html-details -o coverage/coverage.html --gcov-ignore-errors no_working_dir_found \
+          --exclude 'third_party/.*'
     - uses: actions/upload-artifact@v4
       with:
         name: coverage

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = src tests
 
 CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
+# Exclude bundled third party libraries from coverage
+CODE_COVERAGE_IGNORE_PATTERN = */third_party/*
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,11 @@ CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
 # Exclude bundled third party libraries from coverage
 CODE_COVERAGE_IGNORE_PATTERN = */third_party/*
 
+# Ship third-party headers required by tests in the distribution
+dist_noinst_HEADERS = \
+    third_party/nuklear/nuklear.h \
+    third_party/nuklear/nuklear_sdl_gl3.h
+
 include $(top_srcdir)/aminclude_static.am
 
 clean-local: code-coverage-clean


### PR DESCRIPTION
## Summary
- exclude `third_party` from coverage generation
- update CI workflow to skip `third_party` when running `gcovr`

## Testing
- `autoreconf -i`
- `./configure --enable-code-coverage`
- `make -j$(nproc)`
- `make check`
- `make check-code-coverage`
- `gcovr -r . --html-details -o coverage/coverage.html --gcov-ignore-errors no_working_dir_found --exclude 'third_party/.*'`


------
https://chatgpt.com/codex/tasks/task_e_6862972124608322a503e66bea11655c