### PR TITLE
Handle matrix-only transforms in object builder

### DIFF
--- a/src/math/mat4x4.c
+++ b/src/math/mat4x4.c
@@ -483,3 +483,35 @@ inline powergl_vec3 powergl_unproject( powergl_vec3 win, powergl_mat4 mvp, power
   return result.xyz;
   // printf("w division pos = %f %f %f\n", result->x, result->y, result->z);
 }
+
+inline void powergl_decompose_matrix(powergl_mat4 m,
+                                     powergl_vec3 *loc,
+                                     powergl_vec3 *rot,
+                                     powergl_vec3 *sca) {
+  if(loc){
+    loc->x = m.c[3].x;
+    loc->y = m.c[3].y;
+    loc->z = m.c[3].z;
+  }
+
+  if(sca){
+    sca->x = sqrtf(m.c[0].x * m.c[0].x + m.c[0].y * m.c[0].y + m.c[0].z * m.c[0].z);
+    sca->y = sqrtf(m.c[1].x * m.c[1].x + m.c[1].y * m.c[1].y + m.c[1].z * m.c[1].z);
+    sca->z = sqrtf(m.c[2].x * m.c[2].x + m.c[2].y * m.c[2].y + m.c[2].z * m.c[2].z);
+  }
+
+  powergl_mat4 r = m;
+  r.c[0].x /= sca->x; r.c[0].y /= sca->x; r.c[0].z /= sca->x;
+  r.c[1].x /= sca->y; r.c[1].y /= sca->y; r.c[1].z /= sca->y;
+  r.c[2].x /= sca->z; r.c[2].y /= sca->z; r.c[2].z /= sca->z;
+
+  float ry = asinf(r.c[2].x);
+  float rx = atan2f(-r.c[2].y, r.c[2].z);
+  float rz = atan2f(-r.c[1].x, r.c[0].x);
+
+  if(rot){
+    rot->x = rx;
+    rot->y = ry;
+    rot->z = rz;
+  }
+}

--- a/src/math/mat4x4.h
+++ b/src/math/mat4x4.h
@@ -30,4 +30,6 @@ powergl_mat4 powergl_mat4_lookatRH(powergl_vec3 eye, powergl_vec3 center, powerg
 powergl_mat4 powergl_mat4_perspectiveRH(float fovy, float aspect, float zNear, float zFar);
 powergl_vec4 powergl_vec4_trans(powergl_vec4 v, powergl_mat4  m);
 powergl_vec3 powergl_unproject( powergl_vec3 win, powergl_mat4 mvp, powergl_vec4 viewport);
+void powergl_decompose_matrix(powergl_mat4 m, powergl_vec3 *loc,
+                              powergl_vec3 *rot, powergl_vec3 *sca);
 #endif

--- a/src/rendering/dae2object.c
+++ b/src/rendering/dae2object.c
@@ -43,6 +43,7 @@ tokens parse_sid(const char *str){
 }
 
 
+
 void powergl_build_animation(powergl_collada_core_library_animations *anim_lib, powergl_object *obj) {
 #if DEBUG_OUTPUT
   printf("\n%s\n", __func__);
@@ -667,22 +668,36 @@ void powergl_build_object(powergl_collada_core_node  *node, powergl_collada_core
   if(node->n_translate > 0 || node->n_rotate > 0) {
     powergl_build_transform(node, obj, axis_convert);
   } else if(node->n_matrix > 0) {
-    powergl_mat4_copy(&obj->transform.local, node->c_matrix[0]->content,
+    powergl_mat4 m;
+    powergl_mat4_copy(&m, node->c_matrix[0]->content,
                       node->c_matrix[0]->n_content, 1);
+
+    powergl_vec3 r;
+    powergl_decompose_matrix(m, &obj->transform.location, &r, &obj->transform.scale);
+
+    obj->transform.rotation_x = (powergl_vec4){{1.0f,0.0f,0.0f,r.x}};
+    obj->transform.rotation_y = (powergl_vec4){{0.0f,1.0f,0.0f,r.y}};
+    obj->transform.rotation_z = (powergl_vec4){{0.0f,0.0f,1.0f,r.z}};
+
+    obj->transform.local = powergl_mat4_ident();
+    obj->transform.local = powergl_mat4_scale(obj->transform.local, obj->transform.scale);
+    obj->transform.local = powergl_mat4_rot(obj->transform.local, obj->transform.rotation_z.w, obj->transform.rotation_z.xyz);
+    obj->transform.local = powergl_mat4_rot(obj->transform.local, obj->transform.rotation_y.w, obj->transform.rotation_y.xyz);
+    obj->transform.local = powergl_mat4_rot(obj->transform.local, obj->transform.rotation_x.w, obj->transform.rotation_x.xyz);
+    obj->transform.local = powergl_mat4_translate(obj->transform.local, obj->transform.location);
+
     if(obj->parent != NULL){
-      obj->transform.world =
-          powergl_mat4_mul(obj->parent->transform.world, obj->transform.local);
+      obj->transform.world = powergl_mat4_mul(obj->parent->transform.world, obj->transform.local);
     } else {
       obj->transform.world = obj->transform.local;
     }
+
     if(axis_convert && obj->parent == NULL){
       obj->transform.local = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.local);
       obj->transform.world = powergl_mat4_mul(POWERGL_ZUP_TO_YUP, obj->transform.world);
     }
-    obj->transform.location.x = obj->transform.local.c[3].x;
-    obj->transform.location.y = obj->transform.local.c[3].y;
-    obj->transform.location.z = obj->transform.local.c[3].z;
-    obj->transform.matrix_flag = 0;
+
+    obj->transform.matrix_flag = 1;
   } else {
     powergl_transform_reset(&obj->transform);
   }// if node has transform


### PR DESCRIPTION
## Summary
- extract translation, rotation, and scale from transformation matrices
- rebuild object transforms from decomposed components so cameras work
- expose `powergl_decompose_matrix` in math module

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_686081b0b858832294b781a5a70b9d73