### PR TITLE
Add point light pipeline

### DIFF
--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -11,6 +11,7 @@
 static powergl_pipeline *last_ppl;
 static powergl_pipeline2 *last_ppl2;
 static powergl_pipeline3 *last_ppl3;
+static powergl_pipeline4 *last_ppl4;
 static powergl_object *last_obj;
 
 static void render3(powergl_pipeline3 *ppl, powergl_object **objs, size_t n_object){
@@ -252,6 +253,97 @@ void powergl_pipeline_render(powergl_pipeline *ppl, powergl_object **objs, size_
 
     last_ppl = ppl;
     
+    return;
+}
+
+static void render4(powergl_pipeline4 *ppl, powergl_object **objs, size_t n_object){
+
+  powergl_object *obj = NULL;
+
+  for(size_t i = 0; i < n_object; ++i) {
+    obj = objs[i];
+
+    if(obj->n_object > 0){
+      render4(ppl, obj->objects, obj->n_object);
+    }
+
+    if(obj->geometry.visible_flag == 0){
+      continue;
+    }
+
+    if(last_obj != objs[i]){
+      glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
+      glUniformMatrix4fv(ppl->uni_model, 1, GL_FALSE, obj->transform.world.data);
+      glUniform1i(ppl->uni_sampler, 0);
+    } else if(obj->transform.mvp_flag == 1){
+      glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
+      glUniformMatrix4fv(ppl->uni_model, 1, GL_FALSE, obj->transform.world.data);
+      obj->transform.mvp_flag = 0;
+    }
+
+    glBindVertexArray(obj->geometry.vao);
+
+    if(obj->geometry.vertex_flag == 1) {
+      glBindBuffer(GL_ARRAY_BUFFER, obj->geometry.vbo);
+      glBufferData(GL_ARRAY_BUFFER, sizeof(powergl_vec3) * obj->geometry.n_vertex,  obj->geometry.vertex, GL_STATIC_DRAW);
+      obj->geometry.vertex_flag = 0;
+    }
+
+    if ( obj->geometry.triangles.normal_flag == 1 ) {
+      glBindBuffer( GL_ARRAY_BUFFER, obj->geometry.nbo );
+      glBufferData( GL_ARRAY_BUFFER, sizeof( powergl_vec3 ) * obj->geometry.triangles.n_normal, obj->geometry.triangles.normal, GL_STATIC_DRAW );
+      obj->geometry.triangles.normal_flag = 0;
+    }
+
+    if ( obj->geometry.triangles.color_flag == 1 ) {
+      glBindBuffer( GL_ARRAY_BUFFER, obj->geometry.cbo );
+      glBufferData( GL_ARRAY_BUFFER, sizeof( powergl_vec3 ) * obj->geometry.triangles.n_color, obj->geometry.triangles.color, GL_STATIC_DRAW );
+      obj->geometry.triangles.color_flag = 0;
+    }
+
+    if ( obj->geometry.triangles.texcoord_flag == 1 ) {
+      glBindBuffer( GL_ARRAY_BUFFER, obj->geometry.tcbo );
+      glBufferData( GL_ARRAY_BUFFER, sizeof( powergl_vec3 ) * obj->geometry.triangles.n_texcoord, obj->geometry.triangles.texcoord, GL_STATIC_DRAW );
+      obj->geometry.triangles.texcoord_flag = 0;
+    }
+
+#if DEBUG_OUTPUT
+    for(size_t j=0; j < obj->geometry.n_vertex; j++){
+      powergl_vec4 vec = {.xyz=obj->geometry.vertex[j], .w1 = 1.0f};
+      powergl_vec4_print("transformed", powergl_vec4_trans(vec, obj->transform.mvp));
+    }
+#endif
+
+    glDrawArrays( GL_TRIANGLES, 0, obj->geometry.n_vertex );
+
+    last_obj = obj;
+
+  }
+
+}
+
+void powergl_pipeline4_render(powergl_pipeline4 *ppl, powergl_object **objs, size_t n_object, powergl_object *light){
+
+    if(ppl!=last_ppl4){
+
+      // restore uniforms
+      glUseProgram(ppl->gp);
+
+      // restore global states
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+    }
+
+    if (light->light.color_flag == 1) {
+      glUniform3fv( ppl->uni_light_color, 1, light->light.color.data);
+      light->light.color_flag = 0;
+    }
+
+    glUniform3fv( ppl->uni_light_pos, 1, light->transform.location.data);
+
+    render4(ppl, objs, n_object);
+
+    last_ppl4 = ppl;
+
     return;
 }
 
@@ -591,6 +683,100 @@ void powergl_pipeline_create(powergl_pipeline *ppl, powergl_object **objs, size_
   ppl->uni_sampler = glGetUniformLocation( ppl->gp, "texUnit" );
 
   powergl_pipeline_create_objects(ppl, objs, n_obj);
+
+  return;
+}
+
+void powergl_pipeline4_create(powergl_pipeline4 *ppl, powergl_object **objs, size_t n_obj) {
+
+  /*vertex shader input attibute specs*/
+
+  /*vertex input*/
+  ppl->vis.index = 0;
+  ppl->vis.size = 3;
+  ppl->vis.type = GL_FLOAT;
+  ppl->vis.normalized = GL_FALSE;
+  ppl->vis.stride = 0;
+  ppl->vis.offset = 0;
+
+  /* normal input */
+  ppl->nis.index = 1;
+  ppl->nis.size = 3;
+  ppl->nis.type = GL_FLOAT;
+  ppl->nis.normalized = GL_FALSE;
+  ppl->nis.stride = 0;
+  ppl->nis.offset = 0;
+
+  /* color input */
+  ppl->cis.index = 2;
+  ppl->cis.size = 3;
+  ppl->cis.type = GL_FLOAT;
+  ppl->cis.normalized = GL_FALSE;
+  ppl->cis.stride = 0;
+  ppl->cis.offset = 0;
+
+  /* texcoord input */
+  ppl->tcis.index = 3;
+  ppl->tcis.size = 2;
+  ppl->tcis.type = GL_FLOAT;
+  ppl->tcis.normalized = GL_FALSE;
+  ppl->tcis.stride = 0;
+  ppl->tcis.offset = 0;
+
+  /*shader compiler input specs*/
+  const GLchar *const vsrc[] = { "#version 330 core\n"
+    "layout( location = 0 ) in vec3 vPosition;\n"
+    "layout( location = 1 ) in vec3 vNormal;\n"
+    "layout( location = 2 ) in vec3 vColor;\n"
+    "layout( location = 3 ) in vec2 vTexCoord;\n"
+    "out vec3 colorToFs;\n"
+    "out vec2 texCoordToFs;\n"
+    "uniform mat4 mvp;\n"
+    "uniform mat4 model;\n"
+    "uniform vec3 lightColor;\n"
+    "uniform vec3 lightPos;\n"
+    "void main(){\n"
+    "  vec3 ambient = vec3(0.1f, 0.1f, 0.1f);\n"
+    "  vec3 fragPos = vec3(model * vec4(vPosition, 1.0f));\n"
+    "  vec3 lightDir = normalize(lightPos - fragPos);\n"
+    "  float diff = max(dot(vNormal, lightDir), 0.0);\n"
+    "  colorToFs = ambient + vColor * (lightColor * diff);\n"
+    "  texCoordToFs = vTexCoord;\n"
+    "  gl_Position = mvp * vec4(vPosition, 1.0f);\n"
+    "}" };
+
+  const GLchar *const fsrc[] = {"#version 330 core\n"
+    "in vec3 colorToFs;\n"
+    "in vec2 texCoordToFs;\n"
+    "out vec4 fColor;\n"
+    "uniform sampler2D texUnit;\n"
+    "void main(){\n"
+    "  vec4 texColor = texture(texUnit, texCoordToFs);\n"
+    "  fColor = texColor * vec4(colorToFs, 1.0f);\n"
+    "}" };
+
+  /*vertex shader*/
+  ppl->vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(ppl->vs, 1, vsrc, NULL);
+  glCompileShader(ppl->vs);
+  /*fragment shader*/
+  ppl->fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(ppl->fs, 1, fsrc, NULL);
+  glCompileShader(ppl->fs);
+  /*program*/
+  ppl->gp = glCreateProgram();
+  glAttachShader(ppl->gp, ppl->vs);
+  glAttachShader(ppl->gp, ppl->fs);
+  glLinkProgram(ppl->gp);
+  /*uniform*/
+  glUseProgram(ppl->gp);
+  ppl->uni_matrix = glGetUniformLocation(ppl->gp, "mvp");
+  ppl->uni_model = glGetUniformLocation(ppl->gp, "model");
+  ppl->uni_light_color = glGetUniformLocation( ppl->gp, "lightColor" );
+  ppl->uni_light_pos = glGetUniformLocation( ppl->gp, "lightPos" );
+  ppl->uni_sampler = glGetUniformLocation( ppl->gp, "texUnit" );
+
+  powergl_pipeline_create_objects((powergl_pipeline*)ppl, objs, n_obj);
 
   return;
 }

--- a/src/rendering/pipeline.h
+++ b/src/rendering/pipeline.h
@@ -11,6 +11,7 @@
 typedef struct powergl_pipeline_t powergl_pipeline;
 typedef struct powergl_pipeline2_t powergl_pipeline2;
 typedef struct powergl_pipeline3_t powergl_pipeline3;
+typedef struct powergl_pipeline4_t powergl_pipeline4;
 
 typedef struct {
   GLuint index;
@@ -54,6 +55,21 @@ struct powergl_pipeline3_t {
   int forceUpdate;
 };
 
+struct powergl_pipeline4_t {
+  powergl_vsis vis;
+  powergl_vsis nis;
+  powergl_vsis cis;
+  powergl_vsis tcis;
+  GLuint vs;
+  GLuint fs;
+  GLuint gp;
+  GLint uni_matrix;
+  GLint uni_model;
+  GLint uni_light_color;
+  GLint uni_light_pos;
+  GLint uni_sampler;
+};
+
 
 void powergl_pipeline_create(powergl_pipeline *, powergl_object **objs, size_t n_obj);
 void powergl_pipeline_render(powergl_pipeline *, powergl_object **, size_t, powergl_object *);
@@ -63,4 +79,7 @@ void powergl_pipeline2_render(powergl_pipeline2 *, powergl_object **, size_t);
 
 void powergl_pipeline3_create(powergl_pipeline3 *, powergl_object **objs, size_t n_obj);
 void powergl_pipeline3_render(powergl_pipeline3 *, powergl_object **, size_t);
+
+void powergl_pipeline4_create(powergl_pipeline4 *, powergl_object **objs, size_t n_obj);
+void powergl_pipeline4_render(powergl_pipeline4 *, powergl_object **, size_t, powergl_object *);
 #endif

--- a/src/rendering/visualscene.h
+++ b/src/rendering/visualscene.h
@@ -28,6 +28,7 @@ struct powergl_visualscene_t {
   powergl_pipeline pipeline;
   powergl_pipeline2 pipeline2;
   powergl_pipeline3 pipeline3;
+  powergl_pipeline4 pipeline4;
 
   fprun_visualscene run;
   fpcreate_visualscene create;


### PR DESCRIPTION
## Summary
- add `powergl_pipeline4` with uniforms for point lighting
- expose new pipeline in headers and visualscene structure
- implement creation and rendering functions for the point light pipeline

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686388f8a1848322bee8dfdcf4c27ca9