### PR TITLE
Add reusable scene hierarchy UI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,9 @@ AC_CHECK_FUNCS([strtol strtoul])
 
 AC_CONFIG_FILES([Makefile
 		src/Makefile
-		src/rendering/Makefile
-		src/math/Makefile
+                src/rendering/Makefile
+                src/ui/Makefile
+                src/math/Makefile
 		src/collada/Makefile
 		src/collada/core/Makefile
 		src/window/Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,6 +3,7 @@ AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 SUBDIRS = \
         window \
         rendering \
+        ui \
         math \
         collada \
         png
@@ -17,6 +18,7 @@ libpowergl_la_SOURCES = \
 libpowergl_la_LIBADD = \
         window/libpowerglwindow.la \
         rendering/libpowerglrendering.la \
+        ui/libpowerglui.la \
         math/libpowerglmath.la \
         collada/libpowerglcollada.la \
         png/libpowerglpng.la \

--- a/src/ui/Makefile.am
+++ b/src/ui/Makefile.am
@@ -1,0 +1,17 @@
+AM_CPPFLAGS = -I$(top_srcdir)/ui $(CODE_COVERAGE_CPPFLAGS)
+AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
+
+noinst_LTLIBRARIES = libpowerglui.la
+libpowerglui_ladir = $(includedir)/powergl/ui
+libpowerglui_la_HEADERS = \
+        scene_hierarchy.h
+libpowerglui_la_LDFLAGS = -no-undefined
+libpowerglui_la_SOURCES = \
+        scene_hierarchy.c \
+        nuklear_impl.c
+libpowerglui_la_LIBADD = $(CODE_COVERAGE_LIBS)
+
+include $(top_srcdir)/aminclude_static.am
+
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean

--- a/src/ui/nuklear_impl.c
+++ b/src/ui/nuklear_impl.c
@@ -1,0 +1,14 @@
+#define NK_INCLUDE_FIXED_TYPES
+#define NK_INCLUDE_DEFAULT_ALLOCATOR
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+#define NK_INCLUDE_STANDARD_IO
+#define NK_INCLUDE_STANDARD_VARARGS
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+#define NK_IMPLEMENTATION
+#define NK_SDL_GL3_IMPLEMENTATION
+#include "../../third_party/nuklear/nuklear.h"
+#include "../../third_party/nuklear/nuklear_sdl_gl3.h"

--- a/src/ui/scene_hierarchy.c
+++ b/src/ui/scene_hierarchy.c
@@ -1,0 +1,38 @@
+#include "scene_hierarchy.h"
+
+void powergl_ui_draw_object_tree(struct nk_context *ctx, powergl_object *obj){
+    const char *label = obj->id ? obj->id : "object";
+    if(nk_tree_push_id(ctx, NK_TREE_NODE, label, NK_MINIMIZED, (int)(intptr_t)obj)){
+        nk_labelf(ctx, NK_TEXT_LEFT, "Name: %s", label);
+        nk_labelf(ctx, NK_TEXT_LEFT, "Translate: %.2f %.2f %.2f",
+                  obj->transform.location.x,
+                  obj->transform.location.y,
+                  obj->transform.location.z);
+        nk_labelf(ctx, NK_TEXT_LEFT, "Rotation: %.2f %.2f %.2f",
+                  obj->transform.rotation_x.w,
+                  obj->transform.rotation_y.w,
+                  obj->transform.rotation_z.w);
+        nk_labelf(ctx, NK_TEXT_LEFT, "Scale: %.2f %.2f %.2f",
+                  obj->transform.scale.x,
+                  obj->transform.scale.y,
+                  obj->transform.scale.z);
+        for(size_t i = 0; i < obj->n_object; ++i)
+            powergl_ui_draw_object_tree(ctx, obj->objects[i]);
+        nk_tree_pop(ctx);
+    }
+}
+
+void powergl_ui_draw_scene_hierarchy(struct nk_context *ctx,
+                                     powergl_visualscene *scene,
+                                     struct nk_rect bounds){
+    if(nk_begin(ctx, "Scene Hierarchy", bounds,
+                NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|
+                NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE)){
+        if(nk_tree_push(ctx, NK_TREE_NODE, "visual_scene", NK_MINIMIZED)){
+            for(size_t i = 0; i < scene->n_object; ++i)
+                powergl_ui_draw_object_tree(ctx, scene->objects[i]);
+            nk_tree_pop(ctx);
+        }
+    }
+    nk_end(ctx);
+}

--- a/src/ui/scene_hierarchy.h
+++ b/src/ui/scene_hierarchy.h
@@ -1,0 +1,12 @@
+#ifndef _powergl_scene_hierarchy_h
+#define _powergl_scene_hierarchy_h
+
+#include "../rendering/visualscene.h"
+#include "../../third_party/nuklear/nuklear.h"
+
+void powergl_ui_draw_object_tree(struct nk_context *ctx, powergl_object *obj);
+void powergl_ui_draw_scene_hierarchy(struct nk_context *ctx,
+                                     powergl_visualscene *scene,
+                                     struct nk_rect bounds);
+
+#endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -4,15 +4,6 @@
 #include <png.h>
 #include <string.h>
 #include <stdlib.h>
-#define NK_INCLUDE_FIXED_TYPES
-#define NK_INCLUDE_DEFAULT_ALLOCATOR
-#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
-#define NK_INCLUDE_FONT_BAKING
-#define NK_INCLUDE_DEFAULT_FONT
-#define NK_INCLUDE_STANDARD_IO
-#define NK_INCLUDE_STANDARD_VARARGS
-#define NK_IMPLEMENTATION
-#define NK_SDL_GL3_IMPLEMENTATION
 #include "third_party/nuklear/nuklear.h"
 #include "third_party/nuklear/nuklear_sdl_gl3.h"
 #include "src/window/window.h"
@@ -20,6 +11,7 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/pipeline.h"
+#include "src/ui/scene_hierarchy.h"
 
 #define MAX_VERTEX_MEMORY (512 * 1024)
 #define MAX_ELEMENT_MEMORY (128 * 1024)
@@ -32,29 +24,6 @@ static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
 
-static void draw_object_tree(powergl_object *obj){
-    const char *label = obj->id ? obj->id : "object";
-    if(nk_tree_push_id(nkctx, NK_TREE_NODE, label, NK_MINIMIZED, (int)(intptr_t)obj)){
-        nk_labelf(nkctx, NK_TEXT_LEFT, "Name: %s", label);
-        nk_labelf(nkctx, NK_TEXT_LEFT, "Translate: %.2f %.2f %.2f",
-                  obj->transform.location.x,
-                  obj->transform.location.y,
-                  obj->transform.location.z);
-        nk_labelf(nkctx, NK_TEXT_LEFT, "Rotation: %.2f %.2f %.2f",
-                  obj->transform.rotation_x.w,
-                  obj->transform.rotation_y.w,
-                  obj->transform.rotation_z.w);
-        nk_labelf(nkctx, NK_TEXT_LEFT, "Scale: %.2f %.2f %.2f",
-                  obj->transform.scale.x,
-                  obj->transform.scale.y,
-                  obj->transform.scale.z);
-
-        for(size_t i = 0; i < obj->n_object; ++i){
-            draw_object_tree(obj->objects[i]);
-        }
-        nk_tree_pop(nkctx);
-    }
-}
 
 static void save_png(const char *filename){
     GLint vp[4];
@@ -265,17 +234,8 @@ int main(){
             }
             nk_end(nkctx);
 
-            if(nk_begin(nkctx, "Scene Hierarchy", nk_rect(250,10,250,400),
-                NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|
-                NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE)){
-                if(nk_tree_push(nkctx, NK_TREE_NODE, "visual_scene", NK_MINIMIZED)){
-                    for(size_t i = 0; i < scene.n_object; ++i){
-                        draw_object_tree(scene.objects[i]);
-                    }
-                    nk_tree_pop(nkctx);
-                }
-            }
-            nk_end(nkctx);
+            powergl_ui_draw_scene_hierarchy(nkctx, &scene,
+                                           nk_rect(250,10,250,400));
 
             nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
 


### PR DESCRIPTION
## Summary
- add a UI module that renders visual scene hierarchy using Nuklear
- compile Nuklear implementation once in the engine
- expose `powergl_ui_draw_scene_hierarchy` for demos
- use the new helper in the vertex colored cube demo

## Testing
- `autoreconf -i`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68653d7567188322b81c38227dbbcc70