### PR TITLE
Fix CMake build without FindEGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
-project(PowerGL C)
+project(PowerGL C CXX)
 
 set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 17)
 
 # Dependencies
 find_package(OpenGL REQUIRED)
@@ -9,9 +10,18 @@ find_package(PNG REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(EXPAT REQUIRED)
-find_package(EGL REQUIRED)
 
-include_directories(${SDL2_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS})
+# EGL support is provided by FindOpenGL in modern CMake versions.  Using
+# a separate find_package(EGL) call fails on systems without a dedicated
+# FindEGL.cmake module, so rely on the variables exported by FindOpenGL
+# instead.
+
+include_directories(
+    ${SDL2_INCLUDE_DIRS}
+    ${GLEW_INCLUDE_DIRS}
+    ${PNG_INCLUDE_DIRS}
+    ${OPENGL_EGL_INCLUDE_DIR}
+)
 
 add_library(powergl
     src/powergl.c
@@ -23,6 +33,8 @@ add_library(powergl
     src/rendering/dae2object.c
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
+    src/ui/scene_hierarchy.c
+    src/ui/nuklear_impl.c
     src/math/mat4x4.c
     src/math/vec3.c
     src/math/intersect.c
@@ -38,13 +50,17 @@ target_link_libraries(powergl PUBLIC
     ${SDL2_LIBRARIES}
     ${OPENGL_gl_LIBRARY}
     ${GLEW_LIBRARIES}
-    ${EGL_LIBRARIES}
+    ${OPENGL_egl_LIBRARY}
     ${PNG_LIBRARIES}
     ${EXPAT_LIBRARIES}
+    m
 )
 
 target_include_directories(powergl PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
+
+enable_testing()
+add_subdirectory(tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# CMake configuration for unit tests
+
+find_package(GTest REQUIRED)
+
+# Build GoogleTest executables
+add_executable(gtest_math gtest_math.cpp)
+target_compile_definitions(gtest_math PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(gtest_math PRIVATE powergl GTest::gtest_main)
+
+gtest_discover_tests(gtest_math)
+
+add_executable(gtest_collada gtest_collada.cpp)
+target_compile_definitions(gtest_collada PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(gtest_collada PRIVATE powergl GTest::gtest_main)
+
+gtest_discover_tests(gtest_collada)
+
+add_executable(vertexcoloredcube_demo vertexcoloredcube_demo.c)
+target_compile_definitions(vertexcoloredcube_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(vertexcoloredcube_demo PRIVATE powergl)
+
+add_test(NAME vertexcoloredcube_headless
+          COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_vertexcoloredcube_headless.sh
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+


### PR DESCRIPTION
## Summary
- rely on `FindOpenGL` variables for EGL detection
- include EGL headers and library from `FindOpenGL`
- link against math library
- add GoogleTest unit tests and headless demo from autotools build

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_686566e8b1dc832299adc6db6d6a1408