### PR TITLE
Add compile-time selectable window backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,20 @@ find_package(PNG REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(EXPAT REQUIRED)
+set(POWERGL_WINDOW_BACKEND "SDL" CACHE STRING "Window backend implementation (SDL or GLFW)")
+set_property(CACHE POWERGL_WINDOW_BACKEND PROPERTY STRINGS SDL GLFW)
+
+if(POWERGL_WINDOW_BACKEND STREQUAL "GLFW")
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(GLFW REQUIRED glfw3)
+    set(BACKEND_SOURCES src/window/window_glfw.c)
+    add_definitions(-DPOWERGL_BACKEND_GLFW)
+    list(APPEND BACKEND_LIBS ${GLFW_LIBRARIES})
+    include_directories(${GLFW_INCLUDE_DIRS})
+else()
+    set(BACKEND_SOURCES src/window/window_sdl.c)
+    add_definitions(-DPOWERGL_BACKEND_SDL)
+endif()
 
 # EGL support is provided by FindOpenGL in modern CMake versions.  Using
 # a separate find_package(EGL) call fails on systems without a dedicated
@@ -21,12 +35,18 @@ include_directories(
     ${GLEW_INCLUDE_DIRS}
     ${PNG_INCLUDE_DIRS}
     ${OPENGL_EGL_INCLUDE_DIR}
+    
+)
+
+set(POWERGL_WINDOW_SOURCES
+    src/window/window.c
+    src/window/headless.c
+    ${BACKEND_SOURCES}
 )
 
 add_library(powergl
     src/powergl.c
-    src/window/window.c
-    src/window/headless.c
+    ${POWERGL_WINDOW_SOURCES}
     src/rendering/object.c
     src/rendering/pipeline.c
     src/rendering/visualscene.c
@@ -54,6 +74,8 @@ target_link_libraries(powergl PUBLIC
     ${PNG_LIBRARIES}
     ${EXPAT_LIBRARIES}
     m
+    ${BACKEND_LIBS}
+    
 )
 
 target_include_directories(powergl PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(
 set(POWERGL_WINDOW_SOURCES
     src/window/window.c
     src/window/headless.c
+    src/window/event.h
     ${BACKEND_SOURCES}
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,23 @@ AC_CHECK_LIB([GLEW], [glewInit])
 AC_CHECK_LIB([EGL], [eglGetDisplay])
 AC_CHECK_LIB([png16], [png_read_image])
 
+AC_ARG_WITH([window-backend],
+    AS_HELP_STRING([--with-window-backend=@<:@sdl|glfw@:>@],
+                   [Choose window backend]),
+    [window_backend=$withval], [window_backend=sdl])
+AS_CASE([$window_backend],
+    [glfw], [
+        PKG_CHECK_MODULES([GLFW], [glfw3],
+            [AC_DEFINE([POWERGL_BACKEND_GLFW], [1], [Use GLFW backend])],
+            [AC_MSG_ERROR([glfw3 not found])])
+        AM_CONDITIONAL([GLFW_BACKEND], [true])
+    ],
+    [sdl], [
+        AC_DEFINE([POWERGL_BACKEND_SDL], [1], [Use SDL backend])
+        AM_CONDITIONAL([GLFW_BACKEND], [false])
+    ],
+    [AC_MSG_ERROR([Unknown backend: $window_backend])])
+
 # Check for Google Test using pkg-config
 PKG_CHECK_MODULES([GTEST], [gtest_main], [], [AC_MSG_ERROR([Google Test not found])])
 

--- a/src/rendering/object.c
+++ b/src/rendering/object.c
@@ -227,7 +227,7 @@ void powergl_object_update_mvp(powergl_object *obj, powergl_object *cam){
 }
 
 void powergl_object_fps_controller(powergl_object *obj, float delta_time){
-  powergl_event e = obj->event;
+  powergl_input_state e = obj->input;
   powergl_vec3 mov;
   mov.x = 0;
   mov.y = 0;
@@ -263,65 +263,62 @@ void powergl_object_fps_controller(powergl_object *obj, float delta_time){
   
 }
 
-void powergl_event_handle(powergl_object *obj, SDL_Event *event, float delta_time){
+void powergl_event_handle(powergl_object *obj, const powergl_event *event, float delta_time){
 	
   if(obj->event_flag == 1){
     
     switch (event->type) {
-     
-    case SDL_KEYDOWN:
-      
-      switch (event->key.keysym.sym) {
-
-      case SDLK_a:
-	obj->event.key_a_pressed = 1;
-	break;
-      case SDLK_d:
-	obj->event.key_d_pressed = 1;
-	break;
-      case SDLK_w:
-	obj->event.key_w_pressed = 1;
-	break;
-      case SDLK_s:
-	obj->event.key_s_pressed = 1;
-	break;
-      case SDLK_SPACE:
-	obj->event.key_space_pressed = 1;
-	break;
-      case SDLK_LCTRL:
-	obj->event.key_lctrl_pressed = 1;
-	break;	
-      }
-      
-      break;
-
-    case SDL_KEYUP:
-
-      switch (event->key.keysym.sym) {
-
-      case SDLK_a:
-	obj->event.key_a_pressed = 0;
-	break;
-      case SDLK_d:
-	obj->event.key_d_pressed = 0;
-	break;
-      case SDLK_w:
-	obj->event.key_w_pressed = 0;
-	break;
-      case SDLK_s:
-	obj->event.key_s_pressed = 0;
-	break;
-      case SDLK_SPACE:
-	obj->event.key_space_pressed = 0;
-	break;
-      case SDLK_LCTRL:
-	obj->event.key_lctrl_pressed = 0;
-	break;	
-      }
-
-      break;
-      
-    }    
+    case POWERGL_EVENT_KEY_DOWN:
+        switch (event->key) {
+        case POWERGL_KEY_A:
+            obj->input.key_a_pressed = 1;
+            break;
+        case POWERGL_KEY_D:
+            obj->input.key_d_pressed = 1;
+            break;
+        case POWERGL_KEY_W:
+            obj->input.key_w_pressed = 1;
+            break;
+        case POWERGL_KEY_S:
+            obj->input.key_s_pressed = 1;
+            break;
+        case POWERGL_KEY_SPACE:
+            obj->input.key_space_pressed = 1;
+            break;
+        case POWERGL_KEY_LEFT_CTRL:
+            obj->input.key_lctrl_pressed = 1;
+            break;
+        default:
+            break;
+        }
+        break;
+    case POWERGL_EVENT_KEY_UP:
+        switch (event->key) {
+        case POWERGL_KEY_A:
+            obj->input.key_a_pressed = 0;
+            break;
+        case POWERGL_KEY_D:
+            obj->input.key_d_pressed = 0;
+            break;
+        case POWERGL_KEY_W:
+            obj->input.key_w_pressed = 0;
+            break;
+        case POWERGL_KEY_S:
+            obj->input.key_s_pressed = 0;
+            break;
+        case POWERGL_KEY_SPACE:
+            obj->input.key_space_pressed = 0;
+            break;
+        case POWERGL_KEY_LEFT_CTRL:
+            obj->input.key_lctrl_pressed = 0;
+            break;
+        default:
+            break;
+        }
+        break;
+    default:
+        break;
+    }
   }
 }
 

--- a/src/rendering/object.h
+++ b/src/rendering/object.h
@@ -10,7 +10,7 @@
 #include "../math/mat4x4.h"
 #include "../png/png_loader.h"
 
-#include <SDL2/SDL_events.h>
+#include "../window/event.h"
 
 typedef struct powergl_object_t powergl_object;
 typedef struct powergl_transform_t powergl_transform;
@@ -19,7 +19,7 @@ typedef struct powergl_camera_t powergl_camera;
 typedef struct powergl_light_t powergl_light;
 typedef struct powergl_animation_t powergl_animation;
 typedef struct powergl_animation_channel_t powergl_animation_channel;
-typedef struct powergl_event_t powergl_event;
+typedef struct powergl_input_state_t powergl_input_state;
 typedef struct powergl_collider_t powergl_collider;
 typedef struct powergl_texture_t powergl_texture;
 
@@ -34,7 +34,7 @@ struct powergl_collider_t {
   powergl_collider *nodes[8];
 };
 
-struct powergl_event_t {
+struct powergl_input_state_t {
   char key_w_pressed;
   char key_s_pressed;
   char key_a_pressed;
@@ -189,8 +189,8 @@ struct powergl_object_t {
   // collider object
   powergl_collider *collider;
 
-  // event
-  powergl_event event;
+  // input state
+  powergl_input_state input;
 
   // geometry
   powergl_geometry geometry;
@@ -232,7 +232,7 @@ void powergl_camera_update(powergl_object *obj);
 void powergl_object_update_transform(powergl_object *obj, float delta_time);
 void powergl_object_update_mvp(powergl_object *obj, powergl_object *cam);
 void powergl_object_fps_controller(powergl_object *obj, float delta_time);
-void powergl_event_handle(powergl_object *obj, SDL_Event *e, float delta_time);
+void powergl_event_handle(powergl_object *obj, const powergl_event *e, float delta_time);
 void powergl_object_geometry_append(powergl_geometry *dest, powergl_geometry *src, powergl_vec3 offset, powergl_vec3 color);
 void powergl_object_geometry_reset(powergl_geometry *geo);
 

--- a/src/rendering/visualscene.h
+++ b/src/rendering/visualscene.h
@@ -2,15 +2,15 @@
 #define _powergl_visualscene_h
 
 #include <stddef.h>
-#include <SDL2/SDL.h>
 #include "object.h"
 #include "pipeline.h"
+#include "../window/event.h"
 
 typedef struct powergl_visualscene_t powergl_visualscene;
 
 typedef void (*fpcreate_visualscene)(powergl_visualscene *);
 typedef void (*fprun_visualscene)(powergl_visualscene *, float);
-typedef void (*fphandle_events_visualscene)(powergl_visualscene *, SDL_Event *e, float);
+typedef void (*fphandle_events_visualscene)(powergl_visualscene *, powergl_event *e, float);
 
 struct powergl_visualscene_t {
 

--- a/src/window/Makefile.am
+++ b/src/window/Makefile.am
@@ -4,7 +4,8 @@ noinst_LTLIBRARIES = libpowerglwindow.la
 libpowerglwindow_ladir = $(includedir)/powergl/window
 libpowerglwindow_la_HEADERS = \
         window.h \
-        headless.h
+        headless.h \
+        event.h
 libpowerglwindow_la_LDFLAGS = -no-undefined
 libpowerglwindow_la_SOURCES = \
         window.c \

--- a/src/window/Makefile.am
+++ b/src/window/Makefile.am
@@ -9,7 +9,15 @@ libpowerglwindow_la_LDFLAGS = -no-undefined
 libpowerglwindow_la_SOURCES = \
         window.c \
         headless.c
+if GLFW_BACKEND
+libpowerglwindow_la_SOURCES += window_glfw.c
+libpowerglwindow_la_LIBADD = $(CODE_COVERAGE_LIBS) -lEGL $(GLFW_LIBS)
+AM_CPPFLAGS += $(GLFW_CFLAGS) -DPOWERGL_BACKEND_GLFW
+else
+libpowerglwindow_la_SOURCES += window_sdl.c
 libpowerglwindow_la_LIBADD = $(CODE_COVERAGE_LIBS) -lEGL
+AM_CPPFLAGS += -DPOWERGL_BACKEND_SDL
+endif
 
 include $(top_srcdir)/aminclude_static.am
 

--- a/src/window/event.h
+++ b/src/window/event.h
@@ -1,0 +1,36 @@
+#ifndef POWERGL_EVENT_H
+#define POWERGL_EVENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    POWERGL_EVENT_NONE = 0,
+    POWERGL_EVENT_QUIT,
+    POWERGL_EVENT_KEY_DOWN,
+    POWERGL_EVENT_KEY_UP
+} powergl_event_type;
+
+typedef enum {
+    POWERGL_KEY_UNKNOWN = 0,
+    POWERGL_KEY_A,
+    POWERGL_KEY_D,
+    POWERGL_KEY_W,
+    POWERGL_KEY_S,
+    POWERGL_KEY_SPACE,
+    POWERGL_KEY_LEFT_CTRL
+} powergl_keycode;
+
+typedef struct powergl_event_t {
+    powergl_event_type type;
+    powergl_keycode key;
+    int x;
+    int y;
+} powergl_event;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* POWERGL_EVENT_H */

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -1,6 +1,7 @@
 #include "window.h"
 #include <stdio.h>
 #include <time.h>
+#include <string.h>
 
 enum msgSource {
     SOURCE_API = 0x8246,
@@ -30,89 +31,63 @@ enum msgSeverity {
     SEVERITY_NOTIFICATION = 0x826B,
 };
 
-void errorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
-    fprintf(stderr, "\nSource = [ %d ] \n", (int) source);
-    fprintf(stderr, "Type = [ %d ]\n", (int) type);
-    fprintf(stderr, "Severity = [ %d ]\n", (int) severity);
-    fprintf(stderr, "ID = [ %d ]\n", (int) id);
+static void errorCallback(GLenum source, GLenum type, GLuint id, GLenum severity,
+                          GLsizei length, const GLchar *message, const GLvoid *userParam)
+{
+    fprintf(stderr, "\nSource = [ %d ] \n", (int)source);
+    fprintf(stderr, "Type = [ %d ]\n", (int)type);
+    fprintf(stderr, "Severity = [ %d ]\n", (int)severity);
+    fprintf(stderr, "ID = [ %d ]\n", (int)id);
     fprintf(stderr, "Msg = [ %u %s ]\n", length, (const char *)message);
-
-    if(userParam) {}
+    (void)userParam;
 }
 
-
-powergl_window *powergl_window_new(powergl_visualscene *scene) {
-    powergl_window *wnd =  powergl_resize(NULL, 1, sizeof(powergl_window));
-    wnd->root_scene = scene;
-    return wnd;
-}
-
-int powergl_window_create(powergl_window *wnd, int width, int height) {
-    //Initialization flag
-    int success = 1;
-    wnd->window = NULL;
-    wnd->width = width;
-    wnd->height = height;
-
-    //Initialize SDL
-    if(SDL_Init(SDL_INIT_VIDEO) < 0) {
-        printf("SDL could not initialize! SDL Error: %s\n", SDL_GetError());
-        success = 0;
-    } else {
-        //Use OpenGL 3.1 core
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-/* 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4); */
-        //Create window
-        wnd->window = SDL_CreateWindow("PowerGL Engine", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
-
-        if(wnd->window == NULL) {
-            printf("Window could not be created! SDL Error: %s\n", SDL_GetError());
-            success = 0;
-        } else {
-            //Create context
-            wnd->context = SDL_GL_CreateContext(wnd->window);
-
-            if(wnd->context == NULL) {
-                printf("OpenGL context could not be created! SDL Error: %s\n", SDL_GetError());
-                success = 0;
-            } else {
-                //Initialize GLEW
-                glewExperimental = GL_TRUE;
-                GLenum glewError = glewInit();
-
-                if(glewError != GLEW_OK) {
-                    printf("Error initializing GLEW! %s\n", glewGetErrorString(glewError));
-                }
-
-                //Use Vsync
-                if(SDL_GL_SetSwapInterval(1) < 0) {
-                    printf("Warning: Unable to set VSync! SDL Error: %s\n", SDL_GetError());
-                }
-            }
-        }
-    }
-
-    return success;
-}
-
-static int gl_debug_enabled(void){
+static int gl_debug_enabled(void)
+{
     const char *env = getenv("POWERGL_GL_DEBUG");
     return env && strcmp(env, "1") == 0;
 }
 
-int powergl_window_run(powergl_window *wnd) {
+powergl_window *powergl_window_new(powergl_visualscene *scene)
+{
+    powergl_window *wnd = powergl_resize(NULL, 1, sizeof(*wnd));
+    wnd->root_scene = scene;
+#ifdef POWERGL_BACKEND_GLFW
+    wnd->backend = &powergl_glfw_backend;
+#else
+    wnd->backend = &powergl_sdl_backend;
+#endif
+    wnd->backend_handle = NULL;
+    wnd->width = 0;
+    wnd->height = 0;
+    return wnd;
+}
+
+int powergl_window_create(powergl_window *wnd, int width, int height)
+{
+    wnd->width = width;
+    wnd->height = height;
+    return wnd->backend->backend_create(wnd, width, height);
+}
+
+void powergl_window_destroy(powergl_window *wnd)
+{
+    if(wnd && wnd->backend && wnd->backend->backend_destroy)
+        wnd->backend->backend_destroy(wnd);
+}
+
+int powergl_window_run(powergl_window *wnd)
+{
     if(gl_debug_enabled()) {
         glDebugMessageCallback(errorCallback, NULL);
         glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
         glEnable(GL_DEBUG_OUTPUT);
     }
+
     glEnable(GL_DEPTH_TEST);
-    //glEnable(GL_MULTISAMPLE);
     glClearColor(0.3f, 0.6f, 0.9f, 1.0f);
     wnd->root_scene->create(wnd->root_scene);
+
     float delta_time = 0.0f;
     int quit = 0;
     SDL_Event e;
@@ -120,29 +95,21 @@ int powergl_window_run(powergl_window *wnd) {
     Uint64 last_counter = SDL_GetPerformanceCounter();
     Uint64 frequency = SDL_GetPerformanceFrequency();
 
-
     while(!quit) {
         Uint64 current_counter = SDL_GetPerformanceCounter();
         delta_time = (float)(current_counter - last_counter) / (float)frequency;
-	
-        while(SDL_PollEvent(&e) != 0) {
-	  wnd->root_scene->handle_events(wnd->root_scene, &e, delta_time);
 
-            if(e.type == SDL_QUIT) {
+        while(wnd->backend->backend_poll_event(wnd, &e)) {
+            wnd->root_scene->handle_events(wnd->root_scene, &e, delta_time);
+            if(e.type == SDL_QUIT)
                 quit = 1;
-            }
         }
-	
 
-	
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         wnd->root_scene->run(wnd->root_scene, delta_time);
-        //Update screen
-        SDL_GL_SwapWindow(wnd->window);
-
+        wnd->backend->backend_swap(wnd);
         last_counter = current_counter;
     }
-
 
     return 0;
 }

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <string.h>
+#include <SDL2/SDL.h>
 
 enum msgSource {
     SOURCE_API = 0x8246,
@@ -90,7 +91,7 @@ int powergl_window_run(powergl_window *wnd)
 
     float delta_time = 0.0f;
     int quit = 0;
-    SDL_Event e;
+    powergl_event e;
 
     Uint64 last_counter = SDL_GetPerformanceCounter();
     Uint64 frequency = SDL_GetPerformanceFrequency();
@@ -101,7 +102,7 @@ int powergl_window_run(powergl_window *wnd)
 
         while(wnd->backend->backend_poll_event(wnd, &e)) {
             wnd->root_scene->handle_events(wnd->root_scene, &e, delta_time);
-            if(e.type == SDL_QUIT)
+            if(e.type == POWERGL_EVENT_QUIT)
                 quit = 1;
         }
 

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -1,12 +1,16 @@
 #ifndef _powergl_window_h
 #define _powergl_window_h
 
-#include <SDL2/SDL.h>
 #include <GL/glew.h>
+
+#ifdef POWERGL_BACKEND_SDL
+#include <SDL2/SDL.h>
 #include <SDL2/SDL_opengl.h>
+#endif
 
 #include "../powergl.h"
 #include "../rendering/visualscene.h"
+#include "event.h"
 
 typedef struct window_backend_t window_backend;
 
@@ -17,7 +21,7 @@ typedef struct powergl_window_t powergl_window;
 struct window_backend_t {
     int (*backend_create)(powergl_window *, int, int);
     void (*backend_destroy)(powergl_window *);
-    int (*backend_poll_event)(powergl_window *, SDL_Event *);
+    int (*backend_poll_event)(powergl_window *, powergl_event *);
     void (*backend_swap)(powergl_window *);
 };
 
@@ -31,12 +35,12 @@ struct powergl_window_t {
 
 #ifdef POWERGL_BACKEND_SDL
 extern const window_backend powergl_sdl_backend;
+struct SDL_Window;
+SDL_Window *powergl_window_get_sdl_window(powergl_window *);
 #endif
 #ifdef POWERGL_BACKEND_GLFW
 extern const window_backend powergl_glfw_backend;
 #endif
-
-SDL_Window *powergl_window_get_sdl_window(powergl_window *);
 
 powergl_window *powergl_window_new(powergl_visualscene *scene);
 int powergl_window_create(powergl_window *, int, int);

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -8,20 +8,39 @@
 #include "../powergl.h"
 #include "../rendering/visualscene.h"
 
+typedef struct window_backend_t window_backend;
+
 
 typedef struct powergl_window_t powergl_window;
 
 
+struct window_backend_t {
+    int (*backend_create)(powergl_window *, int, int);
+    void (*backend_destroy)(powergl_window *);
+    int (*backend_poll_event)(powergl_window *, SDL_Event *);
+    void (*backend_swap)(powergl_window *);
+};
+
 struct powergl_window_t {
     powergl_visualscene *root_scene;
-    SDL_Window *window;
-    SDL_GLContext context;
+    const window_backend *backend;
+    void *backend_handle;
     int width;
     int height;
 };
 
+#ifdef POWERGL_BACKEND_SDL
+extern const window_backend powergl_sdl_backend;
+#endif
+#ifdef POWERGL_BACKEND_GLFW
+extern const window_backend powergl_glfw_backend;
+#endif
+
+SDL_Window *powergl_window_get_sdl_window(powergl_window *);
+
 powergl_window *powergl_window_new(powergl_visualscene *scene);
 int powergl_window_create(powergl_window *, int, int);
+void powergl_window_destroy(powergl_window *);
 int powergl_window_run(powergl_window *);
 
 

--- a/src/window/window_glfw.c
+++ b/src/window/window_glfw.c
@@ -6,7 +6,36 @@
 
 typedef struct {
     GLFWwindow *window;
+    int has_event;
+    powergl_event event;
 } glfw_backend_data;
+
+static void key_callback(GLFWwindow *window, int key, int scancode, int action, int mods)
+{
+    powergl_window *wnd = glfwGetWindowUserPointer(window);
+    if(!wnd) return;
+    glfw_backend_data *data = wnd->backend_handle;
+    if(!data) return;
+
+    data->has_event = 1;
+    data->event.key = POWERGL_KEY_UNKNOWN;
+    switch(key) {
+    case GLFW_KEY_A: data->event.key = POWERGL_KEY_A; break;
+    case GLFW_KEY_D: data->event.key = POWERGL_KEY_D; break;
+    case GLFW_KEY_W: data->event.key = POWERGL_KEY_W; break;
+    case GLFW_KEY_S: data->event.key = POWERGL_KEY_S; break;
+    case GLFW_KEY_SPACE: data->event.key = POWERGL_KEY_SPACE; break;
+    case GLFW_KEY_LEFT_CONTROL: data->event.key = POWERGL_KEY_LEFT_CTRL; break;
+    default: break;
+    }
+    if(action == GLFW_PRESS)
+        data->event.type = POWERGL_EVENT_KEY_DOWN;
+    else if(action == GLFW_RELEASE)
+        data->event.type = POWERGL_EVENT_KEY_UP;
+    else
+        data->event.type = POWERGL_EVENT_NONE;
+}
+
 
 static int glfw_create(powergl_window *wnd, int width, int height)
 {
@@ -26,6 +55,9 @@ static int glfw_create(powergl_window *wnd, int width, int height)
         return 0;
     }
 
+    glfwSetWindowUserPointer(win, wnd);
+    glfwSetKeyCallback(win, key_callback);
+
     glfwMakeContextCurrent(win);
     if(glewInit() != GLEW_OK)
         fprintf(stderr, "Failed to init GLEW\n");
@@ -34,6 +66,7 @@ static int glfw_create(powergl_window *wnd, int width, int height)
 
     glfw_backend_data *data = calloc(1, sizeof(*data));
     data->window = win;
+    data->has_event = 0;
     wnd->backend_handle = data;
     return 1;
 }
@@ -49,13 +82,17 @@ static void glfw_destroy(powergl_window *wnd)
     wnd->backend_handle = NULL;
 }
 
-static int glfw_poll_event(powergl_window *wnd, SDL_Event *e)
+static int glfw_poll_event(powergl_window *wnd, powergl_event *e)
 {
     glfw_backend_data *data = wnd->backend_handle;
-    (void)data;
+    if(data->has_event) {
+        *e = data->event;
+        data->has_event = 0;
+        return 1;
+    }
     glfwPollEvents();
     if(glfwWindowShouldClose(data->window)) {
-        e->type = SDL_QUIT;
+        e->type = POWERGL_EVENT_QUIT;
         glfwSetWindowShouldClose(data->window, GLFW_FALSE);
         return 1;
     }

--- a/src/window/window_glfw.c
+++ b/src/window/window_glfw.c
@@ -1,0 +1,76 @@
+#include "window.h"
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    GLFWwindow *window;
+} glfw_backend_data;
+
+static int glfw_create(powergl_window *wnd, int width, int height)
+{
+    if(!glfwInit()) {
+        fprintf(stderr, "Failed to initialize GLFW\n");
+        return 0;
+    }
+
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+    GLFWwindow *win = glfwCreateWindow(width, height, "PowerGL Engine", NULL, NULL);
+    if(!win) {
+        fprintf(stderr, "Failed to create GLFW window\n");
+        glfwTerminate();
+        return 0;
+    }
+
+    glfwMakeContextCurrent(win);
+    if(glewInit() != GLEW_OK)
+        fprintf(stderr, "Failed to init GLEW\n");
+
+    glfwSwapInterval(1);
+
+    glfw_backend_data *data = calloc(1, sizeof(*data));
+    data->window = win;
+    wnd->backend_handle = data;
+    return 1;
+}
+
+static void glfw_destroy(powergl_window *wnd)
+{
+    glfw_backend_data *data = wnd->backend_handle;
+    if(!data)
+        return;
+    glfwDestroyWindow(data->window);
+    glfwTerminate();
+    free(data);
+    wnd->backend_handle = NULL;
+}
+
+static int glfw_poll_event(powergl_window *wnd, SDL_Event *e)
+{
+    glfw_backend_data *data = wnd->backend_handle;
+    (void)data;
+    glfwPollEvents();
+    if(glfwWindowShouldClose(data->window)) {
+        e->type = SDL_QUIT;
+        glfwSetWindowShouldClose(data->window, GLFW_FALSE);
+        return 1;
+    }
+    return 0;
+}
+
+static void glfw_swap(powergl_window *wnd)
+{
+    glfw_backend_data *data = wnd->backend_handle;
+    glfwSwapBuffers(data->window);
+}
+
+const window_backend powergl_glfw_backend = {
+    glfw_create,
+    glfw_destroy,
+    glfw_poll_event,
+    glfw_swap
+};

--- a/src/window/window_sdl.c
+++ b/src/window/window_sdl.c
@@ -59,10 +59,45 @@ static void sdl_destroy(powergl_window *wnd)
     wnd->backend_handle = NULL;
 }
 
-static int sdl_poll_event(powergl_window *wnd, SDL_Event *e)
+static int sdl_poll_event(powergl_window *wnd, powergl_event *evt)
 {
     (void)wnd;
-    return SDL_PollEvent(e);
+    SDL_Event e;
+    if(!SDL_PollEvent(&e))
+        return 0;
+    switch(e.type) {
+    case SDL_QUIT:
+        evt->type = POWERGL_EVENT_QUIT;
+        break;
+    case SDL_KEYDOWN:
+        evt->type = POWERGL_EVENT_KEY_DOWN;
+        switch(e.key.keysym.sym) {
+        case SDLK_a: evt->key = POWERGL_KEY_A; break;
+        case SDLK_d: evt->key = POWERGL_KEY_D; break;
+        case SDLK_w: evt->key = POWERGL_KEY_W; break;
+        case SDLK_s: evt->key = POWERGL_KEY_S; break;
+        case SDLK_SPACE: evt->key = POWERGL_KEY_SPACE; break;
+        case SDLK_LCTRL: evt->key = POWERGL_KEY_LEFT_CTRL; break;
+        default: evt->key = POWERGL_KEY_UNKNOWN; break;
+        }
+        break;
+    case SDL_KEYUP:
+        evt->type = POWERGL_EVENT_KEY_UP;
+        switch(e.key.keysym.sym) {
+        case SDLK_a: evt->key = POWERGL_KEY_A; break;
+        case SDLK_d: evt->key = POWERGL_KEY_D; break;
+        case SDLK_w: evt->key = POWERGL_KEY_W; break;
+        case SDLK_s: evt->key = POWERGL_KEY_S; break;
+        case SDLK_SPACE: evt->key = POWERGL_KEY_SPACE; break;
+        case SDLK_LCTRL: evt->key = POWERGL_KEY_LEFT_CTRL; break;
+        default: evt->key = POWERGL_KEY_UNKNOWN; break;
+        }
+        break;
+    default:
+        evt->type = POWERGL_EVENT_NONE;
+        break;
+    }
+    return 1;
 }
 
 static void sdl_swap(powergl_window *wnd)

--- a/src/window/window_sdl.c
+++ b/src/window/window_sdl.c
@@ -1,0 +1,85 @@
+#include "window.h"
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+    SDL_Window *window;
+    SDL_GLContext context;
+} sdl_backend_data;
+
+static int sdl_create(powergl_window *wnd, int width, int height)
+{
+    sdl_backend_data *data = calloc(1, sizeof(*data));
+    wnd->backend_handle = data;
+
+    if(SDL_Init(SDL_INIT_VIDEO) < 0) {
+        printf("SDL could not initialize! SDL Error: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+    data->window = SDL_CreateWindow("PowerGL Engine", SDL_WINDOWPOS_UNDEFINED,
+                                     SDL_WINDOWPOS_UNDEFINED, width, height,
+                                     SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+    if(!data->window) {
+        printf("Window could not be created! SDL Error: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    data->context = SDL_GL_CreateContext(data->window);
+    if(!data->context) {
+        printf("OpenGL context could not be created! SDL Error: %s\n",
+               SDL_GetError());
+        return 0;
+    }
+
+    glewExperimental = GL_TRUE;
+    GLenum glewError = glewInit();
+    if(glewError != GLEW_OK)
+        printf("Error initializing GLEW! %s\n", glewGetErrorString(glewError));
+
+    if(SDL_GL_SetSwapInterval(1) < 0)
+        printf("Warning: Unable to set VSync! SDL Error: %s\n", SDL_GetError());
+
+    return 1;
+}
+
+static void sdl_destroy(powergl_window *wnd)
+{
+    sdl_backend_data *data = wnd->backend_handle;
+    if(!data)
+        return;
+    SDL_GL_DeleteContext(data->context);
+    SDL_DestroyWindow(data->window);
+    SDL_Quit();
+    free(data);
+    wnd->backend_handle = NULL;
+}
+
+static int sdl_poll_event(powergl_window *wnd, SDL_Event *e)
+{
+    (void)wnd;
+    return SDL_PollEvent(e);
+}
+
+static void sdl_swap(powergl_window *wnd)
+{
+    sdl_backend_data *data = wnd->backend_handle;
+    SDL_GL_SwapWindow(data->window);
+}
+
+SDL_Window *powergl_window_get_sdl_window(powergl_window *wnd)
+{
+    sdl_backend_data *data = wnd->backend_handle;
+    return data ? data->window : NULL;
+}
+
+const window_backend powergl_sdl_backend = {
+    sdl_create,
+    sdl_destroy,
+    sdl_poll_event,
+    sdl_swap
+};

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -12,6 +12,7 @@
 #include "src/rendering/object.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
+#include "src/window/event.h"
 
 #define MAX_VERTEX_MEMORY (512 * 1024)
 #define MAX_ELEMENT_MEMORY (128 * 1024)
@@ -138,7 +139,7 @@ static void scene_create(powergl_visualscene *scene){
     powergl_pipeline3_create(&scene->pipeline3, cube_list, 1);
 }
 
-static void scene_events(powergl_visualscene *scene, SDL_Event *e, float dt){
+static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
     if(cube)
         powergl_event_handle(cube, e, dt);
 }
@@ -196,7 +197,8 @@ int main(){
         wnd->root_scene->create(wnd->root_scene);
         wnd->root_scene->pipeline3.forceUpdate = 1;
 
-        SDL_Event e;
+        SDL_Event sdl_e;
+        powergl_event e;
         int quit = 0;
         Uint64 last_counter = SDL_GetPerformanceCounter();
         Uint64 freq = SDL_GetPerformanceFrequency();
@@ -206,11 +208,43 @@ int main(){
             float dt = (float)(current_counter - last_counter) / (float)freq;
 
             nk_input_begin(nkctx);
-            while(SDL_PollEvent(&e)){
-                nk_sdl_handle_event(&e);
-                scene.handle_events(&scene, &e, dt);
-                if(e.type == SDL_QUIT)
+            while(SDL_PollEvent(&sdl_e)){
+                nk_sdl_handle_event(&sdl_e);
+                switch(sdl_e.type){
+                case SDL_QUIT:
+                    e.type = POWERGL_EVENT_QUIT;
+                    scene.handle_events(&scene, &e, dt);
                     quit = 1;
+                    break;
+                case SDL_KEYDOWN:
+                    e.type = POWERGL_EVENT_KEY_DOWN;
+                    switch(sdl_e.key.keysym.sym){
+                    case SDLK_a: e.key = POWERGL_KEY_A; break;
+                    case SDLK_d: e.key = POWERGL_KEY_D; break;
+                    case SDLK_w: e.key = POWERGL_KEY_W; break;
+                    case SDLK_s: e.key = POWERGL_KEY_S; break;
+                    case SDLK_SPACE: e.key = POWERGL_KEY_SPACE; break;
+                    case SDLK_LCTRL: e.key = POWERGL_KEY_LEFT_CTRL; break;
+                    default: e.key = POWERGL_KEY_UNKNOWN; break;
+                    }
+                    scene.handle_events(&scene, &e, dt);
+                    break;
+                case SDL_KEYUP:
+                    e.type = POWERGL_EVENT_KEY_UP;
+                    switch(sdl_e.key.keysym.sym){
+                    case SDLK_a: e.key = POWERGL_KEY_A; break;
+                    case SDLK_d: e.key = POWERGL_KEY_D; break;
+                    case SDLK_w: e.key = POWERGL_KEY_W; break;
+                    case SDLK_s: e.key = POWERGL_KEY_S; break;
+                    case SDLK_SPACE: e.key = POWERGL_KEY_SPACE; break;
+                    case SDLK_LCTRL: e.key = POWERGL_KEY_LEFT_CTRL; break;
+                    default: e.key = POWERGL_KEY_UNKNOWN; break;
+                    }
+                    scene.handle_events(&scene, &e, dt);
+                    break;
+                default:
+                    break;
+                }
             }
             nk_input_end(nkctx);
 

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -188,7 +188,7 @@ int main(){
         if(!powergl_window_create(wnd, 640, 480))
             return 1;
 
-        nkctx = nk_sdl_init(wnd->window);
+        nkctx = nk_sdl_init(powergl_window_get_sdl_window(wnd));
         struct nk_font_atlas *atlas;
         nk_sdl_font_stash_begin(&atlas);
         nk_sdl_font_stash_end();
@@ -240,7 +240,7 @@ int main(){
             nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
 
 
-            SDL_GL_SwapWindow(wnd->window);
+            SDL_GL_SwapWindow(powergl_window_get_sdl_window(wnd));
             last_counter = current_counter;
         }
 


### PR DESCRIPTION
## Summary
- support selecting SDL or GLFW backends at build time
- update build systems and window code for single-backend builds

## Testing
- `autoreconf -fi`
- `./configure`
- `make -j$(nproc) check`


------
https://chatgpt.com/codex/tasks/task_e_68657cd1f97c8322802c67d32036230e