### PR TITLE
Introduce window backend abstraction

### DIFF
--- a/src/window/Makefile.am
+++ b/src/window/Makefile.am
@@ -4,6 +4,7 @@ noinst_LTLIBRARIES = libpowerglwindow.la
 libpowerglwindow_ladir = $(includedir)/powergl/window
 libpowerglwindow_la_HEADERS = \
         window.h \
+        backend.h \
         headless.h \
         window_sdl.h \
         window_glfw.h

--- a/src/window/backend.h
+++ b/src/window/backend.h
@@ -1,0 +1,17 @@
+#ifndef POWERGL_WINDOW_BACKEND_H
+#define POWERGL_WINDOW_BACKEND_H
+
+#include "../event.h"
+
+struct powergl_window_t;
+
+typedef struct powergl_window_backend {
+    int (*create)(struct powergl_window_t *wnd, int width, int height);
+    int (*run)(struct powergl_window_t *wnd);
+    int (*poll_event)(struct powergl_window_t *wnd, powergl_event *ev);
+    void (*swap_buffers)(struct powergl_window_t *wnd);
+    void (*destroy)(struct powergl_window_t *wnd);
+    void *(*get_native_window)(struct powergl_window_t *wnd);
+} powergl_window_backend;
+
+#endif /* POWERGL_WINDOW_BACKEND_H */

--- a/src/window/headless.c
+++ b/src/window/headless.c
@@ -1,4 +1,5 @@
 #include "headless.h"
+#include "window.h"
 #include <string.h>
 #include <stdio.h>
 #include <SDL2/SDL_opengl.h>
@@ -13,6 +14,8 @@ static const EGLint configAttribs[] = {
     EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
     EGL_NONE
 };
+
+typedef powergl_headless headless_backend_data;
 
 powergl_headless *powergl_headless_new(powergl_visualscene *scene){
     powergl_headless *h = calloc(1, sizeof(*h));
@@ -98,3 +101,58 @@ int powergl_headless_run(powergl_headless *h){
     eglTerminate(h->display);
     return 0;
 }
+
+/* Backend interface implementation */
+static int headless_create(powergl_window *wnd, int width, int height)
+{
+    headless_backend_data *h = calloc(1, sizeof(*h));
+    wnd->backend_data = h;
+    h->root_scene = wnd->root_scene;
+    return powergl_headless_create(h, width, height);
+}
+
+static int headless_run(powergl_window *wnd)
+{
+    headless_backend_data *h = (headless_backend_data *)wnd->backend_data;
+    return powergl_headless_run(h);
+}
+
+static int headless_poll_event(powergl_window *wnd, powergl_event *ev)
+{
+    (void)wnd; (void)ev;
+    return 0;
+}
+
+static void headless_swap(powergl_window *wnd)
+{
+    headless_backend_data *h = (headless_backend_data *)wnd->backend_data;
+    eglSwapBuffers(h->display, h->surface);
+}
+
+static void headless_destroy(powergl_window *wnd)
+{
+    headless_backend_data *h = (headless_backend_data *)wnd->backend_data;
+    if(!h)
+        return;
+    eglMakeCurrent(h->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglDestroySurface(h->display, h->surface);
+    eglDestroyContext(h->display, h->context);
+    eglTerminate(h->display);
+    free(h);
+}
+
+static void *headless_get_native_window(powergl_window *wnd)
+{
+    (void)wnd;
+    return NULL;
+}
+
+const powergl_window_backend powergl_window_backend_headless = {
+    .create = headless_create,
+    .run = headless_run,
+    .poll_event = headless_poll_event,
+    .swap_buffers = headless_swap,
+    .destroy = headless_destroy,
+    .get_native_window = headless_get_native_window
+};
+

--- a/src/window/headless.h
+++ b/src/window/headless.h
@@ -4,6 +4,7 @@
 #include <EGL/egl.h>
 #include "../powergl.h"
 #include "../rendering/visualscene.h"
+#include "backend.h"
 
 typedef struct powergl_headless_t powergl_headless;
 
@@ -19,5 +20,7 @@ struct powergl_headless_t {
 powergl_headless *powergl_headless_new(powergl_visualscene *scene);
 int powergl_headless_create(powergl_headless *h, int width, int height);
 int powergl_headless_run(powergl_headless *h);
+
+extern const powergl_window_backend powergl_window_backend_headless;
 
 #endif

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -1,148 +1,54 @@
 #include "window.h"
-#include "window_sdl.h"
-#include <stdio.h>
-#include <time.h>
 
-enum msgSource {
-    SOURCE_API = 0x8246,
-    SOURCE_SYSTEM = 0x8247,
-    SOURCE_SHADER_COMPILER = 0x8248,
-    SOURCE_THIRD_PARTY = 0x8249,
-    SOURCE_APPLICATION = 0x824A,
-    SOURCE_OTHER = 0x824B,
-};
-
-enum msgType {
-    TYPE_ERROR = 0x824C,
-    TYPE_DEPRECATED_BEHAVIOR = 0x824D,
-    TYPE_UNDEFINED_BEHAVIOR = 0x824E,
-    TYPE_PORTABILITY = 0x824F,
-    TYPE_PERFORMANCE = 0x8250,
-    TYPE_OTHER = 0x8251,
-    TYPE_MARKER = 0x8268,
-    TYPE_PUSH_GROUP = 0x8269,
-    TYPE_POP_GROUP = 0x826A,
-};
-
-enum msgSeverity {
-    SEVERITY_HIGH = 0x9146,
-    SEVERITY_MEDIUM = 0x9147,
-    SEVERITY_LOW = 0x9148,
-    SEVERITY_NOTIFICATION = 0x826B,
-};
-
-void errorCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
-    fprintf(stderr, "\nSource = [ %d ] \n", (int) source);
-    fprintf(stderr, "Type = [ %d ]\n", (int) type);
-    fprintf(stderr, "Severity = [ %d ]\n", (int) severity);
-    fprintf(stderr, "ID = [ %d ]\n", (int) id);
-    fprintf(stderr, "Msg = [ %u %s ]\n", length, (const char *)message);
-
-    if(userParam) {}
-}
-
-
-powergl_window *powergl_window_new(powergl_visualscene *scene) {
-    powergl_window *wnd =  powergl_resize(NULL, 1, sizeof(powergl_window));
+powergl_window *powergl_window_new_with_backend(powergl_visualscene *scene,
+                                               const powergl_window_backend *backend)
+{
+    powergl_window *wnd = powergl_resize(NULL, 1, sizeof(*wnd));
     wnd->root_scene = scene;
+    wnd->backend = backend;
+    wnd->backend_data = NULL;
+    wnd->width = wnd->height = 0;
     return wnd;
 }
 
-int powergl_window_create(powergl_window *wnd, int width, int height) {
-    //Initialization flag
-    int success = 1;
-    wnd->window = NULL;
+powergl_window *powergl_window_new(powergl_visualscene *scene)
+{
+    extern const powergl_window_backend powergl_window_backend_sdl; /* defined in window_sdl.c */
+    return powergl_window_new_with_backend(scene, &powergl_window_backend_sdl);
+}
+
+int powergl_window_create(powergl_window *wnd, int width, int height)
+{
     wnd->width = width;
     wnd->height = height;
-
-    //Initialize SDL
-    if(SDL_Init(SDL_INIT_VIDEO) < 0) {
-        printf("SDL could not initialize! SDL Error: %s\n", SDL_GetError());
-        success = 0;
-    } else {
-        //Use OpenGL 3.1 core
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-/* 	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
-	SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4); */
-        //Create window
-        wnd->window = SDL_CreateWindow("PowerGL Engine", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
-
-        if(wnd->window == NULL) {
-            printf("Window could not be created! SDL Error: %s\n", SDL_GetError());
-            success = 0;
-        } else {
-            //Create context
-            wnd->context = SDL_GL_CreateContext(wnd->window);
-
-            if(wnd->context == NULL) {
-                printf("OpenGL context could not be created! SDL Error: %s\n", SDL_GetError());
-                success = 0;
-            } else {
-                //Initialize GLEW
-                glewExperimental = GL_TRUE;
-                GLenum glewError = glewInit();
-
-                if(glewError != GLEW_OK) {
-                    printf("Error initializing GLEW! %s\n", glewGetErrorString(glewError));
-                }
-
-                //Use Vsync
-                if(SDL_GL_SetSwapInterval(1) < 0) {
-                    printf("Warning: Unable to set VSync! SDL Error: %s\n", SDL_GetError());
-                }
-            }
-        }
-    }
-
-    return success;
+    if(!wnd->backend || !wnd->backend->create)
+        return 0;
+    return wnd->backend->create(wnd, width, height);
 }
 
-static int gl_debug_enabled(void){
-    const char *env = getenv("POWERGL_GL_DEBUG");
-    return env && strcmp(env, "1") == 0;
+int powergl_window_run(powergl_window *wnd)
+{
+    if(!wnd->backend || !wnd->backend->run)
+        return 0;
+    return wnd->backend->run(wnd);
 }
 
-int powergl_window_run(powergl_window *wnd) {
-    if(gl_debug_enabled()) {
-        glDebugMessageCallback(errorCallback, NULL);
-        glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
-        glEnable(GL_DEBUG_OUTPUT);
-    }
-    glEnable(GL_DEPTH_TEST);
-    //glEnable(GL_MULTISAMPLE);
-    glClearColor(0.3f, 0.6f, 0.9f, 1.0f);
-    wnd->root_scene->create(wnd->root_scene);
-    float delta_time = 0.0f;
-    int quit = 0;
-    powergl_event ev;
+int powergl_window_poll_event(powergl_window *wnd, powergl_event *ev)
+{
+    if(!wnd->backend || !wnd->backend->poll_event)
+        return 0;
+    return wnd->backend->poll_event(wnd, ev);
+}
 
-    Uint64 last_counter = SDL_GetPerformanceCounter();
-    Uint64 frequency = SDL_GetPerformanceFrequency();
+void powergl_window_swap_buffers(powergl_window *wnd)
+{
+    if(wnd->backend && wnd->backend->swap_buffers)
+        wnd->backend->swap_buffers(wnd);
+}
 
-
-    while(!quit) {
-        Uint64 current_counter = SDL_GetPerformanceCounter();
-        delta_time = (float)(current_counter - last_counter) / (float)frequency;
-	
-        while(powergl_sdl_poll_event(&ev)) {
-            wnd->root_scene->handle_events(wnd->root_scene, &ev, delta_time);
-            if(ev.type == POWERGL_EVENT_WINDOW_CLOSE) {
-                quit = 1;
-            }
-        }
-	
-
-	
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        wnd->root_scene->run(wnd->root_scene, delta_time);
-        //Update screen
-        SDL_GL_SwapWindow(wnd->window);
-
-        last_counter = current_counter;
-    }
-
-
-    return 0;
+void *powergl_window_get_native_window(powergl_window *wnd)
+{
+    if(wnd->backend && wnd->backend->get_native_window)
+        return wnd->backend->get_native_window(wnd);
+    return NULL;
 }

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -1,29 +1,30 @@
 #ifndef _powergl_window_h
 #define _powergl_window_h
 
-#include <SDL2/SDL.h>
-#include <GL/glew.h>
-#include <SDL2/SDL_opengl.h>
-#include "../event.h"
 
 #include "../powergl.h"
 #include "../rendering/visualscene.h"
+#include "backend.h"
 
 
 typedef struct powergl_window_t powergl_window;
 
-
 struct powergl_window_t {
     powergl_visualscene *root_scene;
-    SDL_Window *window;
-    SDL_GLContext context;
+    const powergl_window_backend *backend;
+    void *backend_data;
     int width;
     int height;
 };
 
 powergl_window *powergl_window_new(powergl_visualscene *scene);
+powergl_window *powergl_window_new_with_backend(powergl_visualscene *scene,
+                                               const powergl_window_backend *backend);
 int powergl_window_create(powergl_window *, int, int);
 int powergl_window_run(powergl_window *);
+int powergl_window_poll_event(powergl_window *, powergl_event *ev);
+void powergl_window_swap_buffers(powergl_window *);
+void *powergl_window_get_native_window(powergl_window *);
 
 
 #endif

--- a/src/window/window_sdl.c
+++ b/src/window/window_sdl.c
@@ -1,12 +1,10 @@
+
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+
 #include "window_sdl.h"
 #include "window.h"
-#ifndef GL_ARB_ES2_compatibility
-#define GL_ARB_ES2_compatibility 1
-typedef int GLfixed;
-#endif
-#include <GL/glew.h>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_opengl.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/src/window/window_sdl.c
+++ b/src/window/window_sdl.c
@@ -1,5 +1,19 @@
 #include "window_sdl.h"
+#include "window.h"
+#ifndef GL_ARB_ES2_compatibility
+#define GL_ARB_ES2_compatibility 1
+typedef int GLfixed;
+#endif
+#include <GL/glew.h>
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct {
+    SDL_Window *window;
+    SDL_GLContext context;
+} sdl_backend_data;
 
 static powergl_key translate_key(SDL_Keycode k){
     switch(k){
@@ -69,3 +83,145 @@ int powergl_sdl_poll_event(powergl_event *ev){
     powergl_sdl_translate_event(&e, ev);
     return 1;
 }
+
+/* Backend implementation */
+
+static void errorCallback(GLenum source, GLenum type, GLuint id, GLenum severity,
+                          GLsizei length, const GLchar *message,
+                          const GLvoid *userParam)
+{
+    fprintf(stderr, "\nSource = [ %d ] \n", (int) source);
+    fprintf(stderr, "Type = [ %d ]\n", (int) type);
+    fprintf(stderr, "Severity = [ %d ]\n", (int) severity);
+    fprintf(stderr, "ID = [ %d ]\n", (int) id);
+    fprintf(stderr, "Msg = [ %u %s ]\n", length, (const char *)message);
+    (void)userParam;
+}
+
+static int gl_debug_enabled(void)
+{
+    const char *env = getenv("POWERGL_GL_DEBUG");
+    return env && strcmp(env, "1") == 0;
+}
+
+static int sdl_create(powergl_window *wnd, int width, int height)
+{
+    int success = 1;
+    sdl_backend_data *data = calloc(1, sizeof(*data));
+    wnd->backend_data = data;
+
+    if(SDL_Init(SDL_INIT_VIDEO) < 0) {
+        fprintf(stderr, "SDL could not initialize! SDL Error: %s\n",
+                SDL_GetError());
+        success = 0;
+    } else {
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+        data->window = SDL_CreateWindow("PowerGL Engine",
+                                        SDL_WINDOWPOS_UNDEFINED,
+                                        SDL_WINDOWPOS_UNDEFINED,
+                                        width, height,
+                                        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+        if(!data->window) {
+            fprintf(stderr, "Window could not be created! SDL Error: %s\n",
+                    SDL_GetError());
+            success = 0;
+        } else {
+            data->context = SDL_GL_CreateContext(data->window);
+            if(!data->context) {
+                fprintf(stderr, "OpenGL context could not be created! SDL Error: %s\n",
+                        SDL_GetError());
+                success = 0;
+            } else {
+                glewExperimental = GL_TRUE;
+                GLenum glewError = glewInit();
+                if(glewError != GLEW_OK)
+                    fprintf(stderr, "Error initializing GLEW! %s\n",
+                            glewGetErrorString(glewError));
+
+                if(SDL_GL_SetSwapInterval(1) < 0)
+                    fprintf(stderr, "Warning: Unable to set VSync! SDL Error: %s\n",
+                            SDL_GetError());
+            }
+        }
+    }
+
+    return success;
+}
+
+static int sdl_poll_event(powergl_window *wnd, powergl_event *ev)
+{
+    (void)wnd; /* unused */
+    return powergl_sdl_poll_event(ev);
+}
+
+static void sdl_swap(powergl_window *wnd)
+{
+    sdl_backend_data *data = (sdl_backend_data *)wnd->backend_data;
+    SDL_GL_SwapWindow(data->window);
+}
+
+static int sdl_run(powergl_window *wnd)
+{
+    if(gl_debug_enabled()) {
+        glDebugMessageCallback(errorCallback, NULL);
+        glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, GL_TRUE);
+        glEnable(GL_DEBUG_OUTPUT);
+    }
+    glEnable(GL_DEPTH_TEST);
+    glClearColor(0.3f, 0.6f, 0.9f, 1.0f);
+    wnd->root_scene->create(wnd->root_scene);
+
+    float delta_time = 0.0f;
+    int quit = 0;
+    powergl_event ev;
+    Uint64 last_counter = SDL_GetPerformanceCounter();
+    Uint64 frequency = SDL_GetPerformanceFrequency();
+
+    while(!quit) {
+        Uint64 current_counter = SDL_GetPerformanceCounter();
+        delta_time = (float)(current_counter - last_counter) / (float)frequency;
+
+        while(sdl_poll_event(wnd, &ev)) {
+            wnd->root_scene->handle_events(wnd->root_scene, &ev, delta_time);
+            if(ev.type == POWERGL_EVENT_WINDOW_CLOSE)
+                quit = 1;
+        }
+
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        wnd->root_scene->run(wnd->root_scene, delta_time);
+        sdl_swap(wnd);
+        last_counter = current_counter;
+    }
+    return 0;
+}
+
+static void sdl_destroy(powergl_window *wnd)
+{
+    sdl_backend_data *data = (sdl_backend_data *)wnd->backend_data;
+    if(data) {
+        if(data->context)
+            SDL_GL_DeleteContext(data->context);
+        if(data->window)
+            SDL_DestroyWindow(data->window);
+        free(data);
+    }
+    SDL_Quit();
+}
+
+static void *sdl_get_native_window(powergl_window *wnd)
+{
+    sdl_backend_data *data = (sdl_backend_data *)wnd->backend_data;
+    return data ? (void*)data->window : NULL;
+}
+
+const powergl_window_backend powergl_window_backend_sdl = {
+    .create = sdl_create,
+    .run = sdl_run,
+    .poll_event = sdl_poll_event,
+    .swap_buffers = sdl_swap,
+    .destroy = sdl_destroy,
+    .get_native_window = sdl_get_native_window
+};

--- a/src/window/window_sdl.h
+++ b/src/window/window_sdl.h
@@ -2,10 +2,13 @@
 #define POWERGL_WINDOW_SDL_H
 
 #include "../event.h"
+#include "backend.h"
 
 typedef union SDL_Event SDL_Event;
 
 void powergl_sdl_translate_event(const SDL_Event *src, powergl_event *dst);
 int powergl_sdl_poll_event(powergl_event *ev);
+
+extern const powergl_window_backend powergl_window_backend_sdl;
 
 #endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -179,17 +179,18 @@ int main(){
 
     const char *headless = getenv("POWERGL_HEADLESS");
     if(headless && strcmp(headless, "1") == 0){
-        powergl_headless *h = powergl_headless_new(&scene);
-        if(!powergl_headless_create(h, 640, 480))
+        powergl_window *wnd =
+            powergl_window_new_with_backend(&scene, &powergl_window_backend_headless);
+        if(!powergl_window_create(wnd, 640, 480))
             return 1;
-        int ret = powergl_headless_run(h);
+        int ret = powergl_window_run(wnd);
         return ret || png_mismatch;
     } else {
         powergl_window *wnd = powergl_window_new(&scene);
         if(!powergl_window_create(wnd, 640, 480))
             return 1;
 
-        nkctx = nk_sdl_init(wnd->window);
+        nkctx = nk_sdl_init((SDL_Window *)powergl_window_get_native_window(wnd));
         struct nk_font_atlas *atlas;
         nk_sdl_font_stash_begin(&atlas);
         nk_sdl_font_stash_end();
@@ -243,7 +244,7 @@ int main(){
             nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
 
 
-            SDL_GL_SwapWindow(wnd->window);
+            powergl_window_swap_buffers(wnd);
             last_counter = current_counter;
         }
 


### PR DESCRIPTION
## Summary
- add backend abstraction struct and update window interface
- implement SDL and headless backends
- adjust vertexcoloredcube demo to use the new API
- define GLfixed for SDL backend to build

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc) check` *(fails: unknown type name `GLfixed` from glew.h)*


------
https://chatgpt.com/codex/tasks/task_e_6866fbe57f148322941cd66622e82809