### PR TITLE
Expose PNG helper functions

### DIFF
--- a/src/png/png_loader.c
+++ b/src/png/png_loader.c
@@ -4,6 +4,8 @@
 #include <setjmp.h>
 
 #include "png_loader.h"
+#include <GL/glew.h>
+#include <png.h>
 
 powergl_png powergl_png_load(const char * file){
 
@@ -91,5 +93,105 @@ powergl_png powergl_png_load(const char * file){
   image.color_type = color_type;
 
   return image;
+}
 
+int powergl_png_save(const char *filename){
+  GLint vp[4];
+  glGetIntegerv(GL_VIEWPORT, vp);
+  int width = vp[2];
+  int height = vp[3];
+  size_t size = (size_t)width * height * 4;
+  unsigned char *pixels = (unsigned char*)malloc(size);
+  if(!pixels){
+    fprintf(stderr, "failed to allocate %zu bytes for screenshot\n", size);
+    return 0;
+  }
+  glPixelStorei(GL_PACK_ALIGNMENT, 1);
+  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+  FILE *fp = fopen(filename, "wb");
+  if(!fp){
+    fprintf(stderr, "cannot open %s for writing\n", filename);
+    free(pixels);
+    return 0;
+  }
+
+  png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+  if(!png_ptr){
+    fprintf(stderr, "failed to create png write struct\n");
+    fclose(fp);
+    free(pixels);
+    return 0;
+  }
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if(!info_ptr){
+    fprintf(stderr, "failed to create png info struct\n");
+    png_destroy_write_struct(&png_ptr, NULL);
+    fclose(fp);
+    free(pixels);
+    return 0;
+  }
+  if(setjmp(png_jmpbuf(png_ptr))){
+    fprintf(stderr, "png error writing to %s\n", filename);
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    fclose(fp);
+    free(pixels);
+    return 0;
+  }
+  png_init_io(png_ptr, fp);
+  png_set_IHDR(png_ptr, info_ptr, width, height, 8, PNG_COLOR_TYPE_RGBA,
+               PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+  png_write_info(png_ptr, info_ptr);
+  png_bytep *row_pointers = malloc(sizeof(png_bytep) * height);
+  if(!row_pointers){
+    fprintf(stderr, "failed to allocate row pointers\n");
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    fclose(fp);
+    free(pixels);
+    return 0;
+  }
+  for(int y = 0; y < height; ++y)
+    row_pointers[height - 1 - y] = pixels + y * width * 4;
+  png_write_image(png_ptr, row_pointers);
+  png_write_end(png_ptr, NULL);
+  png_destroy_write_struct(&png_ptr, &info_ptr);
+  free(row_pointers);
+  fclose(fp);
+  free(pixels);
+  return 1;
+}
+
+int powergl_png_compare(const char *a, const char *b){
+  powergl_png pa = powergl_png_load(a);
+  powergl_png pb = powergl_png_load(b);
+  if(!pa.data){
+    fprintf(stderr, "failed to load image %s\n", a);
+    if(pb.data) free(pb.data);
+    return 0;
+  }
+  if(!pb.data){
+    fprintf(stderr, "failed to load image %s\n", b);
+    free(pa.data);
+    return 0;
+  }
+  if(pa.width != pb.width || pa.height != pb.height || pa.color_type != pb.color_type){
+    fprintf(stderr, "image dimensions or color type differ\n");
+    free(pa.data);
+    free(pb.data);
+    return 0;
+  }
+  int bpp = (pa.color_type == PNG_COLOR_TYPE_RGB) ? 3 : 4;
+  size_t size = (size_t)pa.width * pa.height * bpp;
+  int diff = 0;
+  for(size_t i = 0; i < size; ++i){
+    if(abs((int)pa.data[i] - (int)pb.data[i]) > 160){
+      diff = 1;
+      break;
+    }
+  }
+  if(diff)
+    fprintf(stderr, "image data differs between %s and %s\n", a, b);
+  free(pa.data);
+  free(pb.data);
+  return diff ? 0 : 1;
 }

--- a/src/png/png_loader.c
+++ b/src/png/png_loader.c
@@ -4,7 +4,6 @@
 #include <setjmp.h>
 
 #include "png_loader.h"
-#include <GL/glew.h>
 #include <png.h>
 
 powergl_png powergl_png_load(const char * file){
@@ -95,71 +94,6 @@ powergl_png powergl_png_load(const char * file){
   return image;
 }
 
-int powergl_png_save(const char *filename){
-  GLint vp[4];
-  glGetIntegerv(GL_VIEWPORT, vp);
-  int width = vp[2];
-  int height = vp[3];
-  size_t size = (size_t)width * height * 4;
-  unsigned char *pixels = (unsigned char*)malloc(size);
-  if(!pixels){
-    fprintf(stderr, "failed to allocate %zu bytes for screenshot\n", size);
-    return 0;
-  }
-  glPixelStorei(GL_PACK_ALIGNMENT, 1);
-  glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-
-  FILE *fp = fopen(filename, "wb");
-  if(!fp){
-    fprintf(stderr, "cannot open %s for writing\n", filename);
-    free(pixels);
-    return 0;
-  }
-
-  png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-  if(!png_ptr){
-    fprintf(stderr, "failed to create png write struct\n");
-    fclose(fp);
-    free(pixels);
-    return 0;
-  }
-  png_infop info_ptr = png_create_info_struct(png_ptr);
-  if(!info_ptr){
-    fprintf(stderr, "failed to create png info struct\n");
-    png_destroy_write_struct(&png_ptr, NULL);
-    fclose(fp);
-    free(pixels);
-    return 0;
-  }
-  if(setjmp(png_jmpbuf(png_ptr))){
-    fprintf(stderr, "png error writing to %s\n", filename);
-    png_destroy_write_struct(&png_ptr, &info_ptr);
-    fclose(fp);
-    free(pixels);
-    return 0;
-  }
-  png_init_io(png_ptr, fp);
-  png_set_IHDR(png_ptr, info_ptr, width, height, 8, PNG_COLOR_TYPE_RGBA,
-               PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-  png_write_info(png_ptr, info_ptr);
-  png_bytep *row_pointers = malloc(sizeof(png_bytep) * height);
-  if(!row_pointers){
-    fprintf(stderr, "failed to allocate row pointers\n");
-    png_destroy_write_struct(&png_ptr, &info_ptr);
-    fclose(fp);
-    free(pixels);
-    return 0;
-  }
-  for(int y = 0; y < height; ++y)
-    row_pointers[height - 1 - y] = pixels + y * width * 4;
-  png_write_image(png_ptr, row_pointers);
-  png_write_end(png_ptr, NULL);
-  png_destroy_write_struct(&png_ptr, &info_ptr);
-  free(row_pointers);
-  fclose(fp);
-  free(pixels);
-  return 1;
-}
 
 int powergl_png_compare(const char *a, const char *b){
   powergl_png pa = powergl_png_load(a);

--- a/src/png/png_loader.h
+++ b/src/png/png_loader.h
@@ -14,12 +14,6 @@ typedef struct {
 
 powergl_png powergl_png_load(const char * file);
 
-/*
- * Save the current OpenGL framebuffer to a PNG image. The image dimensions
- * are taken from the current viewport. Returns 0 on failure, non-zero on
- * success.
- */
-int powergl_png_save(const char *filename);
 
 /*
  * Compare two PNG images pixel by pixel. Returns 1 if the images have the

--- a/src/png/png_loader.h
+++ b/src/png/png_loader.h
@@ -1,3 +1,6 @@
+#ifndef POWERGL_PNG_LOADER_H
+#define POWERGL_PNG_LOADER_H
+
 #include <png.h>
 
 typedef struct {
@@ -10,3 +13,18 @@ typedef struct {
 } powergl_png;
 
 powergl_png powergl_png_load(const char * file);
+
+/*
+ * Save the current OpenGL framebuffer to a PNG image. The image dimensions
+ * are taken from the current viewport. Returns 0 on failure, non-zero on
+ * success.
+ */
+int powergl_png_save(const char *filename);
+
+/*
+ * Compare two PNG images pixel by pixel. Returns 1 if the images have the
+ * same dimensions and differ by less than a threshold, otherwise returns 0.
+ */
+int powergl_png_compare(const char *a, const char *b);
+
+#endif /* POWERGL_PNG_LOADER_H */

--- a/src/window/window.c
+++ b/src/window/window.c
@@ -1,4 +1,8 @@
+#include <GL/glew.h>
 #include "window.h"
+#include <png.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 powergl_window *powergl_window_new_with_backend(powergl_visualscene *scene,
                                                const powergl_window_backend *backend)
@@ -51,4 +55,71 @@ void *powergl_window_get_native_window(powergl_window *wnd)
     if(wnd->backend && wnd->backend->get_native_window)
         return wnd->backend->get_native_window(wnd);
     return NULL;
+}
+
+int powergl_window_screenshot(const char *filename)
+{
+    GLint vp[4];
+    glGetIntegerv(GL_VIEWPORT, vp);
+    int width = vp[2];
+    int height = vp[3];
+    size_t size = (size_t)width * height * 4;
+    unsigned char *pixels = (unsigned char*)malloc(size);
+    if(!pixels){
+        fprintf(stderr, "failed to allocate %zu bytes for screenshot\n", size);
+        return 0;
+    }
+    glPixelStorei(GL_PACK_ALIGNMENT, 1);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    FILE *fp = fopen(filename, "wb");
+    if(!fp){
+        fprintf(stderr, "cannot open %s for writing\n", filename);
+        free(pixels);
+        return 0;
+    }
+
+    png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    if(!png_ptr){
+        fprintf(stderr, "failed to create png write struct\n");
+        fclose(fp);
+        free(pixels);
+        return 0;
+    }
+    png_infop info_ptr = png_create_info_struct(png_ptr);
+    if(!info_ptr){
+        fprintf(stderr, "failed to create png info struct\n");
+        png_destroy_write_struct(&png_ptr, NULL);
+        fclose(fp);
+        free(pixels);
+        return 0;
+    }
+    if(setjmp(png_jmpbuf(png_ptr))){
+        fprintf(stderr, "png error writing to %s\n", filename);
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        fclose(fp);
+        free(pixels);
+        return 0;
+    }
+    png_init_io(png_ptr, fp);
+    png_set_IHDR(png_ptr, info_ptr, width, height, 8, PNG_COLOR_TYPE_RGBA,
+                 PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+    png_write_info(png_ptr, info_ptr);
+    png_bytep *row_pointers = malloc(sizeof(png_bytep) * height);
+    if(!row_pointers){
+        fprintf(stderr, "failed to allocate row pointers\n");
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        fclose(fp);
+        free(pixels);
+        return 0;
+    }
+    for(int y = 0; y < height; ++y)
+        row_pointers[height - 1 - y] = pixels + y * width * 4;
+    png_write_image(png_ptr, row_pointers);
+    png_write_end(png_ptr, NULL);
+    png_destroy_write_struct(&png_ptr, &info_ptr);
+    free(row_pointers);
+    fclose(fp);
+    free(pixels);
+    return 1;
 }

--- a/src/window/window.h
+++ b/src/window/window.h
@@ -26,5 +26,12 @@ int powergl_window_poll_event(powergl_window *, powergl_event *ev);
 void powergl_window_swap_buffers(powergl_window *);
 void *powergl_window_get_native_window(powergl_window *);
 
+/*
+ * Save the current OpenGL framebuffer to a PNG image. The image dimensions
+ * are taken from the current viewport. Returns 0 on failure, non-zero on
+ * success.
+ */
+int powergl_window_screenshot(const char *filename);
+
 
 #endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -58,7 +58,7 @@ static void scene_run(powergl_visualscene *scene, float dt){
     if(frame_counter < max_frames){
         char fname[64];
         snprintf(fname, sizeof(fname), "frame_%02d.png", frame_counter);
-        powergl_png_save(fname);
+        powergl_window_screenshot(fname);
         char ref[256];
         snprintf(ref, sizeof(ref), "%s/vertexcoloredcube_demo.png", TEST_SRCDIR);
         int same = powergl_png_compare(fname, ref);

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -1,7 +1,6 @@
 #include <SDL2/SDL.h>
 #include <GL/glew.h>
 #include <SDL2/SDL_opengl.h>
-#include <png.h>
 #include <string.h>
 #include <stdlib.h>
 #include "src/event.h"
@@ -13,6 +12,7 @@
 #include "src/rendering/object.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
+#include "src/png/png_loader.h"
 
 #define MAX_VERTEX_MEMORY (512 * 1024)
 #define MAX_ELEMENT_MEMORY (128 * 1024)
@@ -24,107 +24,6 @@ static powergl_object *cube_list[1];
 static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
-
-
-static void save_png(const char *filename){
-    GLint vp[4];
-    glGetIntegerv(GL_VIEWPORT, vp);
-    int width = vp[2];
-    int height = vp[3];
-    size_t size = (size_t)width * height * 4;
-    unsigned char *pixels = (unsigned char*)malloc(size);
-    if(!pixels){
-        printf("failed to allocate %zu bytes for screenshot\n", size);
-        return;
-    }
-    glPixelStorei(GL_PACK_ALIGNMENT, 1);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-
-    FILE *fp = fopen(filename, "wb");
-    if(!fp){
-        printf("cannot open %s for writing\n", filename);
-        free(pixels);
-        return;
-    }
-
-    png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-    if(!png_ptr){
-        printf("failed to create png write struct\n");
-        fclose(fp);
-        free(pixels);
-        return;
-    }
-    png_infop info_ptr = png_create_info_struct(png_ptr);
-    if(!info_ptr){
-        printf("failed to create png info struct\n");
-        png_destroy_write_struct(&png_ptr, NULL);
-        fclose(fp);
-        free(pixels);
-        return;
-    }
-    if(setjmp(png_jmpbuf(png_ptr))){
-        printf("png error writing to %s\n", filename);
-        png_destroy_write_struct(&png_ptr, &info_ptr);
-        fclose(fp);
-        free(pixels);
-        return;
-    }
-    png_init_io(png_ptr, fp);
-    png_set_IHDR(png_ptr, info_ptr, width, height, 8, PNG_COLOR_TYPE_RGBA,
-                 PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-    png_write_info(png_ptr, info_ptr);
-    png_bytep *row_pointers = malloc(sizeof(png_bytep) * height);
-    if(!row_pointers){
-        printf("failed to allocate row pointers\n");
-        png_destroy_write_struct(&png_ptr, &info_ptr);
-        fclose(fp);
-        free(pixels);
-        return;
-    }
-    for(int y = 0; y < height; ++y)
-        row_pointers[height - 1 - y] = pixels + y * width * 4;
-    png_write_image(png_ptr, row_pointers);
-    png_write_end(png_ptr, NULL);
-    png_destroy_write_struct(&png_ptr, &info_ptr);
-    free(row_pointers);
-    fclose(fp);
-    free(pixels);
-}
-
-static int compare_png(const char *a, const char *b){
-    powergl_png pa = powergl_png_load(a);
-    powergl_png pb = powergl_png_load(b);
-    if(!pa.data){
-        printf("failed to load image %s\n", a);
-        if(pb.data) free(pb.data);
-        return 0;
-    }
-    if(!pb.data){
-        printf("failed to load image %s\n", b);
-        free(pa.data);
-        return 0;
-    }
-    if(pa.width != pb.width || pa.height != pb.height || pa.color_type != pb.color_type){
-        printf("image dimensions or color type differ\n");
-        free(pa.data);
-        free(pb.data);
-        return 0;
-    }
-    int bpp = (pa.color_type == PNG_COLOR_TYPE_RGB) ? 3 : 4;
-    size_t size = (size_t)pa.width * pa.height * bpp;
-    int diff = 0;
-    for(size_t i = 0; i < size; ++i){
-        if(abs((int)pa.data[i] - (int)pb.data[i]) > 160){
-            diff = 1;
-            break;
-        }
-    }
-    if(diff)
-        printf("image data differs between %s and %s\n", a, b);
-    free(pa.data);
-    free(pb.data);
-    return diff ? 0 : 1;
-}
 
 static void scene_create(powergl_visualscene *scene){
     const char *dae = TEST_SRCDIR "/vertexcolored_cube.dae";
@@ -159,10 +58,10 @@ static void scene_run(powergl_visualscene *scene, float dt){
     if(frame_counter < max_frames){
         char fname[64];
         snprintf(fname, sizeof(fname), "frame_%02d.png", frame_counter);
-        save_png(fname);
+        powergl_png_save(fname);
         char ref[256];
         snprintf(ref, sizeof(ref), "%s/vertexcoloredcube_demo.png", TEST_SRCDIR);
-        int same = compare_png(fname, ref);
+        int same = powergl_png_compare(fname, ref);
         if(!same)
             png_mismatch = 1;
         printf("frame %d %s reference\n", frame_counter, same ? "matches" : "differs from");


### PR DESCRIPTION
## Summary
- add include guards for the png loader header
- implement `powergl_png_save` and `powergl_png_compare`
- expose the new PNG APIs
- use the new API from `vertexcoloredcube_demo`

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6867d2fb78648322a392f4010d8a7975