### PR TITLE
Add picking and hover highlighting

### DIFF
--- a/src/rendering/object.h
+++ b/src/rendering/object.h
@@ -216,6 +216,10 @@ struct powergl_object_t {
   char light_flag;
   char textured_flag;
 
+  /* interaction state */
+  char hovered;
+  char selected;
+
   // info
   char *id;
   char *name;

--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -56,6 +56,11 @@ static void render3(powergl_pipeline3 *ppl, powergl_object **objs, size_t n_obje
     }
 #endif
 
+    if(obj->selected || obj->hovered)
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     glDrawArrays( GL_TRIANGLES, 0, obj->geometry.n_vertex );
 
     last_obj = obj;
@@ -104,6 +109,11 @@ static void render2(powergl_pipeline2 *ppl, powergl_object **objs, size_t n_obje
       powergl_vec4_print("transformed", powergl_vec4_trans(vec, obj->transform.mvp));
     }
 #endif
+
+    if(obj->selected || obj->hovered)
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     glDrawArrays( GL_TRIANGLES, 0, obj->geometry.n_vertex );
 
@@ -175,6 +185,11 @@ static void render(powergl_pipeline *ppl, powergl_object **objs, size_t n_object
     }
 #endif
 
+    if(obj->selected || obj->hovered)
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     glDrawArrays( GL_TRIANGLES, 0, obj->geometry.n_vertex );
 
     last_obj = obj;
@@ -204,8 +219,11 @@ void powergl_pipeline3_render(powergl_pipeline3 *ppl, powergl_object **objs, siz
       
     render3(ppl, objs, n_object);
 
+    /* restore solid mode for subsequent passes (e.g. UI rendering) */
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     last_ppl3 = ppl;
-    
+
     return;
 }
 
@@ -222,8 +240,11 @@ void powergl_pipeline2_render(powergl_pipeline2 *ppl, powergl_object **objs, siz
       
     render2(ppl, objs, n_object);
 
+    /* ensure next passes start in solid mode */
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     last_ppl2 = ppl;
-    
+
     return;
 }
 
@@ -244,15 +265,18 @@ void powergl_pipeline_render(powergl_pipeline *ppl, powergl_object **objs, size_
       main_light->light.color_flag = 0;
     }
 
-    if (main_light->light.dir_flag == 1) {	  
+    if (main_light->light.dir_flag == 1) {
       glUniform3fv( ppl->uni_light_dir, 1, main_light->light.dir.data);
       main_light->light.dir_flag = 0;
     }
-      
+
     render(ppl, objs, n_object);
 
+    /* reset to solid mode so subsequent draws (e.g. UI) are unaffected */
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     last_ppl = ppl;
-    
+
     return;
 }
 
@@ -314,6 +338,11 @@ static void render4(powergl_pipeline4 *ppl, powergl_object **objs, size_t n_obje
     }
 #endif
 
+    if(obj->selected || obj->hovered)
+      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+    else
+      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
     glDrawArrays( GL_TRIANGLES, 0, obj->geometry.n_vertex );
 
     last_obj = obj;
@@ -341,6 +370,9 @@ void powergl_pipeline4_render(powergl_pipeline4 *ppl, powergl_object **objs, siz
     glUniform3fv( ppl->uni_light_pos, 1, light->transform.location.data);
 
     render4(ppl, objs, n_object);
+
+    /* reset polygon mode for following passes */
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     last_ppl4 = ppl;
 

--- a/src/rendering/visualscene.c
+++ b/src/rendering/visualscene.c
@@ -5,6 +5,7 @@
 #include "../collada/importer.h"
 #include "dae2object.h"
 
+#include <GL/glcorearb.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -67,4 +68,85 @@ powergl_object *powergl_scene_find(powergl_visualscene *scene, const char *id) {
   }
 
   return NULL;
+}
+
+static void pick_recursive(powergl_object **objs, size_t n_obj, powergl_vec2 pos,
+                           powergl_vec4 vp, powergl_object **best_obj,
+                           float *best_dist)
+{
+  for(size_t i = 0; i < n_obj; ++i){
+    powergl_object *obj = objs[i];
+    if(obj->n_object > 0)
+      pick_recursive(obj->objects, obj->n_object, pos, vp, best_obj, best_dist);
+
+    if(obj->geometry.visible_flag == 0)
+      continue;
+
+    for(size_t j = 0; j < obj->geometry.n_vertex; j += 3){
+      powergl_vec3 P;
+      int hit = powergl_intersect_ray_tri_mesh(&obj->geometry.vertex[j], 3,
+                                               obj->transform.mvp, pos, vp,
+                                               &P, 0);
+      if(hit && P.z >= 0.0f && P.z < *best_dist){
+        *best_dist = P.z;
+        *best_obj = obj;
+      }
+    }
+  }
+}
+
+powergl_object *powergl_scene_pick(powergl_visualscene *scene, powergl_object *cam,
+                                   powergl_vec2 mouse, powergl_vec4 viewport,
+                                   float *out_dist)
+{
+  if(!scene || !cam)
+    return NULL;
+
+  float dist = 1e30f;
+  powergl_object *best = NULL;
+
+  /* ensure MVP matrices are up to date */
+  for(size_t i=0;i<scene->n_object;i++)
+    powergl_object_update_mvp(scene->objects[i], cam);
+
+  pick_recursive(scene->objects, scene->n_object, mouse, viewport, &best, &dist);
+
+  if(out_dist)
+    *out_dist = dist;
+  return best;
+}
+
+void powergl_scene_handle_picking(powergl_visualscene *scene, powergl_event *e)
+{
+  if(!scene || !scene->main_camera || !e)
+    return;
+
+  GLint vpdata[4];
+  glGetIntegerv(GL_VIEWPORT, vpdata);
+  powergl_vec4 vp = {(float)vpdata[0], (float)vpdata[1],
+                     (float)vpdata[2], (float)vpdata[3]};
+  powergl_vec2 pos = {(float)e->x, (float)e->y};
+
+  if(e->type == POWERGL_EVENT_MOUSE_MOVE){
+    powergl_object *hit = powergl_scene_pick(scene, scene->main_camera, pos, vp, NULL);
+    if(hit != scene->hovered_object && hit != scene->selected_object){
+      if(scene->hovered_object)
+        scene->hovered_object->hovered = 0;
+      scene->hovered_object = hit;
+      if(hit)
+        hit->hovered = 1;
+    }
+  } else if(e->type == POWERGL_EVENT_MOUSE_BUTTON_DOWN &&
+            e->button == POWERGL_MOUSE_BUTTON_LEFT){
+    powergl_object *hit = powergl_scene_pick(scene, scene->main_camera, pos, vp, NULL);
+    if(scene->selected_object && scene->selected_object != hit){
+      scene->selected_object->selected = 0;
+    }
+    scene->selected_object = hit;
+    if(hit){
+      hit->selected = 1;
+      hit->hovered = 0;
+      scene->hovered_object = NULL;
+    }
+  }
 }

--- a/src/rendering/visualscene.h
+++ b/src/rendering/visualscene.h
@@ -30,6 +30,10 @@ struct powergl_visualscene_t {
   powergl_pipeline3 pipeline3;
   powergl_pipeline4 pipeline4;
 
+  /* interaction state */
+  powergl_object *hovered_object;
+  powergl_object *selected_object;
+
   fprun_visualscene run;
   fpcreate_visualscene create;
   fphandle_events_visualscene handle_events;
@@ -38,5 +42,10 @@ struct powergl_visualscene_t {
 
 void powergl_scene_build(powergl_visualscene *, const char *);
 powergl_object *powergl_scene_find(powergl_visualscene *, const char *);
+powergl_object *powergl_scene_pick(powergl_visualscene *, powergl_object *cam,
+                                   powergl_vec2 mouse,
+                                   powergl_vec4 viewport,
+                                   float *out_dist);
+void powergl_scene_handle_picking(powergl_visualscene *, powergl_event *e);
 
 #endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -39,6 +39,7 @@ static void scene_create(powergl_visualscene *scene){
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
+    powergl_scene_handle_picking(scene, e);
     if(cube)
         powergl_event_handle(cube, e, dt);
 }


### PR DESCRIPTION
## Summary
- extend `powergl_object` with hovered and selected flags
- track hovered and selected objects in `powergl_visualscene`
- implement `powergl_scene_pick` and `powergl_scene_handle_picking`
- update pipelines to draw hovered/selected meshes in wireframe
- restore filled polygon mode after rendering for proper UI drawing
- demo picking in `vertexcoloredcube_demo`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6867ddc57d908322a524579aeb3ad8db