### PR TITLE
Fix Blender Z-up conversion

### DIFF
--- a/src/rendering/dae2object.c
+++ b/src/rendering/dae2object.c
@@ -4,10 +4,19 @@
 #define DEBUG_OUTPUT 1
 #endif
 
+/*
+ * Blender exports scenes using a Z-up coordinate system while
+ * PowerGL assumes Y-up with -Z forward.  The original matrix rotated
+ * the axes in the wrong direction which resulted in Y becoming
+ * downward and Z pointing forward.  This caused imported cameras to
+ * produce a vertical ground plane and movement along the Y axis when
+ * moving "forward".  Rotate by -90 degrees around the X axis instead
+ * so that Blender's +Z maps to +Y and +Y maps to -Z.
+ */
 static const powergl_mat4 POWERGL_ZUP_TO_YUP = { .c = {
     {1.0f, 0.0f, 0.0f, 0.0f},
-    {0.0f, 0.0f, -1.0f, 0.0f},
-    {0.0f, 1.0f, 0.0f, 0.0f},
+    {0.0f, 0.0f, 1.0f, 0.0f},
+    {0.0f, -1.0f, 0.0f, 0.0f},
     {0.0f, 0.0f, 0.0f, 1.0f}
 }};
 

--- a/tests/gtest_collada.cpp
+++ b/tests/gtest_collada.cpp
@@ -53,8 +53,8 @@ TEST(ObjectImport, AxisConversion){
     powergl_mat4 w = cube->transform.world;
     EXPECT_NEAR(w.c[0].x, 1.0f, 1e-5f);
     EXPECT_NEAR(w.c[1].y, 0.0f, 1e-5f);
-    EXPECT_NEAR(w.c[1].z, -1.0f, 1e-5f);
-    EXPECT_NEAR(w.c[2].y, 1.0f, 1e-5f);
+    EXPECT_NEAR(w.c[1].z, 1.0f, 1e-5f);
+    EXPECT_NEAR(w.c[2].y, -1.0f, 1e-5f);
     EXPECT_NEAR(w.c[2].z, 0.0f, 1e-5f);
 }
 


### PR DESCRIPTION
## Summary
- correct Z-up to Y-up conversion matrix

## Testing
- `autoreconf -i`
- `./configure`
- `make check` *(fails: Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68694bf423288322a69b83e473df2b49