### PR TITLE
Add optional grid feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(powergl
     src/rendering/dae2object.c
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
+    src/rendering/grid.c
     src/ui/scene_hierarchy.c
     src/ui/nuklear_impl.c
     src/math/mat4x4.c

--- a/src/rendering/Makefile.am
+++ b/src/rendering/Makefile.am
@@ -8,8 +8,9 @@ libpowerglrendering_la_HEADERS = \
 	pipeline.h \
 	visualscene.h \
 	dae2object.h \
-	objectlibrary.h \
-	3dtext.h
+        objectlibrary.h \
+        3dtext.h \
+        grid.h
 libpowerglrendering_la_LDFLAGS = -no-undefined
 libpowerglrendering_la_SOURCES = \
         object.c \
@@ -17,7 +18,8 @@ libpowerglrendering_la_SOURCES = \
         visualscene.c \
         dae2object.c \
         objectlibrary.c \
-        3dtext.c
+        3dtext.c \
+        grid.c
 libpowerglrendering_la_LIBADD = $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/src/rendering/dae2object.c
+++ b/src/rendering/dae2object.c
@@ -213,6 +213,8 @@ void powergl_build_geometry(powergl_collada_core_node *node, powergl_object *obj
   powergl_collada_core_mesh  *mesh = geo->c_mesh[0];
   
   if(mesh->n_triangles > 0){
+
+    obj->geometry.primitive_type = GL_TRIANGLES;
 	
     powergl_collada_core_triangles *tris = mesh->c_triangles[0];
     powergl_collada_core_ListOfUInts *prim = tris->c_p[0];

--- a/src/rendering/grid.c
+++ b/src/rendering/grid.c
@@ -1,0 +1,36 @@
+#include "grid.h"
+#include <string.h>
+
+void powergl_grid_create(powergl_object *obj, int half_size)
+{
+    if(!obj)
+        return;
+    memset(obj, 0, sizeof(*obj));
+    powergl_transform_reset(&obj->transform);
+
+    int lines = half_size * 2 + 1;
+    int n_vertices = lines * 4;
+
+    obj->geometry.visible_flag = 1;
+    obj->geometry.primitive_type = GL_LINES;
+    obj->geometry.vertex = powergl_resize(NULL, n_vertices, sizeof(powergl_vec3));
+    obj->geometry.n_vertex = n_vertices;
+    obj->geometry.vertex_flag = 1;
+    obj->geometry.triangles.color = powergl_resize(NULL, n_vertices, sizeof(powergl_vec3));
+    obj->geometry.triangles.n_color = n_vertices;
+    obj->geometry.triangles.color_flag = 1;
+
+    powergl_vec3 col = {0.5f, 0.5f, 0.5f};
+    int idx = 0;
+    for(int i = -half_size; i <= half_size; ++i){
+        obj->geometry.vertex[idx]   = (powergl_vec3){(float)i, 0.0f, (float)-half_size};
+        obj->geometry.vertex[idx+1] = (powergl_vec3){(float)i, 0.0f, (float)half_size};
+        obj->geometry.vertex[idx+2] = (powergl_vec3){(float)-half_size, 0.0f, (float)i};
+        obj->geometry.vertex[idx+3] = (powergl_vec3){(float)half_size, 0.0f, (float)i};
+        obj->geometry.triangles.color[idx] = col;
+        obj->geometry.triangles.color[idx+1] = col;
+        obj->geometry.triangles.color[idx+2] = col;
+        obj->geometry.triangles.color[idx+3] = col;
+        idx += 4;
+    }
+}

--- a/src/rendering/grid.h
+++ b/src/rendering/grid.h
@@ -1,0 +1,9 @@
+#ifndef _powergl_grid_h
+#define _powergl_grid_h
+
+#include "object.h"
+
+/* Build a grid of given half size (size lines each direction). */
+void powergl_grid_create(powergl_object *obj, int half_size);
+
+#endif

--- a/src/rendering/object.c
+++ b/src/rendering/object.c
@@ -489,6 +489,8 @@ void powergl_object_geometry_reset(powergl_geometry *geo){
     geo->triangles.n_color = 0;
   }
 
+  geo->primitive_type = GL_TRIANGLES;
+
 }
 
 powergl_object *powergl_camera_default(){

--- a/src/rendering/object.h
+++ b/src/rendering/object.h
@@ -106,6 +106,9 @@ struct powergl_geometry_t {
   GLuint cbo;
   GLuint tcbo;
 
+  /* primitive type for rendering (GL_TRIANGLES, GL_LINES, ...) */
+  GLenum primitive_type;
+
   char visible_flag;
   
   float min_x, min_y, min_z, max_x, max_y, max_z;

--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -15,6 +15,7 @@ static powergl_object *last_obj;
 
 /* Global toggle for drawing selection outlines */
 int powergl_enable_outline = 1;
+int powergl_enable_grid = 1;
 
 static void draw_outline(powergl_object *obj){
   // --- PREPARATION ---
@@ -27,7 +28,7 @@ static void draw_outline(powergl_object *obj){
   glStencilFunc(GL_ALWAYS, 1, 0xFF);
   glStencilMask(0xFF);
   glDepthMask(GL_TRUE); 
-  glDrawArrays(GL_TRIANGLES, 0, obj->geometry.n_vertex);
+  glDrawArrays(obj->geometry.primitive_type, 0, obj->geometry.n_vertex);
 
   // --- PASS 2: DRAW THE OUTLINE ---
   glCullFace(GL_FRONT);
@@ -38,7 +39,7 @@ static void draw_outline(powergl_object *obj){
   glUseProgram(last_ppl3->gpOutline);
   glUniformMatrix4fv(last_ppl3->uni_matrixOutline, 1, GL_FALSE, obj->transform.mvp.data);
 
-  glDrawArrays(GL_TRIANGLES, 0, obj->geometry.n_vertex);
+  glDrawArrays(obj->geometry.primitive_type, 0, obj->geometry.n_vertex);
 
   glStencilMask(0xFF);
   glStencilFunc(GL_ALWAYS, 0, 0xFF);
@@ -93,7 +94,7 @@ static void render3(powergl_pipeline3 *ppl, powergl_object **objs, size_t n_obje
       draw_outline(obj);
     } else {
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-      glDrawArrays(GL_TRIANGLES, 0, obj->geometry.n_vertex);
+      glDrawArrays(obj->geometry.primitive_type, 0, obj->geometry.n_vertex);
     }
 
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -149,7 +150,7 @@ static void render2(powergl_pipeline2 *ppl, powergl_object **objs, size_t n_obje
       draw_outline(obj);
     } else {
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-      glDrawArrays(GL_TRIANGLES, 0, obj->geometry.n_vertex);
+      glDrawArrays(obj->geometry.primitive_type, 0, obj->geometry.n_vertex);
     }
 
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -226,7 +227,7 @@ static void render(powergl_pipeline *ppl, powergl_object **objs, size_t n_object
       draw_outline(obj);
     } else {
       glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-      glDrawArrays(GL_TRIANGLES, 0, obj->geometry.n_vertex);
+      glDrawArrays(obj->geometry.primitive_type, 0, obj->geometry.n_vertex);
     }
 
     glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);

--- a/src/rendering/pipeline.h
+++ b/src/rendering/pipeline.h
@@ -71,4 +71,6 @@ void powergl_pipeline3_render(powergl_pipeline3 *, powergl_object **, size_t);
 
 /* Set to 0 to disable drawing selection outlines */
 extern int powergl_enable_outline;
+/* Set to 0 to disable drawing the grid */
+extern int powergl_enable_grid;
 #endif

--- a/tests/run_vertexcoloredcube_headless.sh
+++ b/tests/run_vertexcoloredcube_headless.sh
@@ -3,4 +3,4 @@
 # vertexcoloredcube_demo binary is available in the current working
 # directory.  Simply invoke it directly to work both in the build tree
 # and in "make distcheck".
-POWERGL_HEADLESS=1 EGL_PLATFORM=surfaceless ./vertexcoloredcube_demo
+POWERGL_ENABLE_GRID=0 POWERGL_HEADLESS=1 EGL_PLATFORM=surfaceless ./vertexcoloredcube_demo

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -10,6 +10,7 @@
 #include "src/window/headless.h"
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
+#include "src/rendering/grid.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
 #include "src/png/png_loader.h"
@@ -20,7 +21,8 @@
 static struct nk_context *nkctx;
 
 static powergl_object *cube;
-static powergl_object *cube_list[1];
+static powergl_object grid;
+static powergl_object *object_list[2];
 static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
@@ -32,10 +34,12 @@ static void scene_create(powergl_visualscene *scene){
     if(!scene->main_camera)
         scene->main_camera = powergl_camera_default();
     cube = powergl_scene_find(scene, "Cube");
-    cube_list[0] = cube;
+    object_list[0] = cube;
+    powergl_grid_create(&grid, 10);
+    object_list[1] = &grid;
     if(cube)
         cube->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, cube_list, 1);
+    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -51,7 +55,9 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_object_update_transform(cube, dt);
         powergl_camera_update(scene->main_camera);
         powergl_object_update_mvp(cube, scene->main_camera);
-        powergl_pipeline3_render(&scene->pipeline3, cube_list, 1);
+        powergl_object_update_mvp(&grid, scene->main_camera);
+        size_t count = powergl_enable_grid ? 2 : 1;
+        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
         scene->main_camera->camera.vp_flag = 0;
     }
 
@@ -73,6 +79,9 @@ static void scene_run(powergl_visualscene *scene, float dt){
 int main(){
     powergl_visualscene scene = {0};
     setenv("POWERGL_GL_DEBUG", "0", 0);
+    const char *grid_env = getenv("POWERGL_ENABLE_GRID");
+    if(grid_env && strcmp(grid_env, "0") == 0)
+        powergl_enable_grid = 0;
     scene.create = scene_create;
     scene.run = scene_run;
     scene.handle_events = scene_events;


### PR DESCRIPTION
## Summary
- allow specifying primitive type for object geometry
- add grid helper to draw lines on the XZ plane
- toggle grid display via `powergl_enable_grid` variable
- render grid in the vertex colored cube demo when enabled
- disable grid in headless demo tests to keep reference images

## Testing
- `autoreconf -i`
- `./configure`
- `make`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68691e5da8d083228dd2d22ffbdb08c4