### PR TITLE
Add orientation gizmo overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(powergl
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
     src/rendering/grid.c
+    src/rendering/gizmo.c
     src/ui/scene_hierarchy.c
     src/ui/nuklear_impl.c
     src/math/mat4x4.c

--- a/src/rendering/Makefile.am
+++ b/src/rendering/Makefile.am
@@ -10,7 +10,8 @@ libpowerglrendering_la_HEADERS = \
 	dae2object.h \
         objectlibrary.h \
         3dtext.h \
-        grid.h
+        grid.h \
+        gizmo.h
 libpowerglrendering_la_LDFLAGS = -no-undefined
 libpowerglrendering_la_SOURCES = \
         object.c \
@@ -19,7 +20,8 @@ libpowerglrendering_la_SOURCES = \
         dae2object.c \
         objectlibrary.c \
         3dtext.c \
-        grid.c
+        grid.c \
+        gizmo.c
 libpowerglrendering_la_LIBADD = $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/src/rendering/gizmo.c
+++ b/src/rendering/gizmo.c
@@ -1,0 +1,69 @@
+#include "gizmo.h"
+#include "pipeline.h"
+#include "../math/mat4x4.h"
+#include <string.h>
+
+static powergl_object gizmo_obj;
+static powergl_object *gizmo_objs[1] = {&gizmo_obj};
+static powergl_pipeline3 gizmo_pipeline;
+static int gizmo_initialized = 0;
+
+void powergl_gizmo_create(powergl_object *obj, float size)
+{
+    if(!obj)
+        return;
+    memset(obj, 0, sizeof(*obj));
+    powergl_transform_reset(&obj->transform);
+
+    obj->geometry.visible_flag = 1;
+    obj->geometry.primitive_type = GL_LINES;
+    obj->geometry.vertex = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.n_vertex = 6;
+    obj->geometry.vertex_flag = 1;
+    obj->geometry.triangles.color = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.triangles.n_color = 6;
+    obj->geometry.triangles.color_flag = 1;
+
+    obj->geometry.vertex[0] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[1] = (powergl_vec3){size, 0.0f, 0.0f};
+    obj->geometry.vertex[2] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[3] = (powergl_vec3){0.0f, size, 0.0f};
+    obj->geometry.vertex[4] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[5] = (powergl_vec3){0.0f, 0.0f, size};
+
+    obj->geometry.triangles.color[0] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[1] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[2] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[3] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[4] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+    obj->geometry.triangles.color[5] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+}
+
+void powergl_gizmo_draw(powergl_object *cam, int width, int height)
+{
+    if(!gizmo_initialized){
+        powergl_gizmo_create(&gizmo_obj, 1.0f);
+        powergl_pipeline3_create(&gizmo_pipeline, gizmo_objs, 1);
+        gizmo_initialized = 1;
+    }
+
+    if(!cam)
+        return;
+
+    powergl_mat4 rot = powergl_mat4_ident();
+    rot = powergl_mat4_rot(rot, cam->transform.rotation_z.w, cam->transform.rotation_z.xyz);
+    rot = powergl_mat4_rot(rot, cam->transform.rotation_y.w, cam->transform.rotation_y.xyz);
+    rot = powergl_mat4_rot(rot, cam->transform.rotation_x.w, cam->transform.rotation_x.xyz);
+    rot = powergl_mat4_transpose(rot);
+
+    powergl_mat4 proj = powergl_mat4_perspectiveRH(powergl_float_to_radians(30.0f), 1.0f, 0.1f, 10.0f);
+    gizmo_obj.transform.mvp = powergl_mat4_mul(proj, rot);
+    gizmo_obj.transform.mvp_flag = 1;
+
+    GLint vp[4];
+    glGetIntegerv(GL_VIEWPORT, vp);
+    int size = 80;
+    glViewport(width - size - 10, height - size - 10, size, size);
+    powergl_pipeline3_render(&gizmo_pipeline, gizmo_objs, 1);
+    glViewport(vp[0], vp[1], vp[2], vp[3]);
+}

--- a/src/rendering/gizmo.h
+++ b/src/rendering/gizmo.h
@@ -1,0 +1,9 @@
+#ifndef _powergl_gizmo_h
+#define _powergl_gizmo_h
+
+#include "object.h"
+
+void powergl_gizmo_create(powergl_object *obj, float size);
+void powergl_gizmo_draw(powergl_object *cam, int width, int height);
+
+#endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -12,6 +12,7 @@
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
 #include "src/rendering/pipeline.h"
+#include "src/rendering/gizmo.h"
 #include "src/ui/scene_hierarchy.h"
 #include "src/png/png_loader.h"
 
@@ -128,6 +129,7 @@ int main(){
             nk_input_end(nkctx);
 
             scene.run(&scene, dt);
+            powergl_gizmo_draw(scene.main_camera, wnd->width, wnd->height);
 
             if(nk_begin(nkctx, "Demo", nk_rect(10,10,230,250),
                 NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|


### PR DESCRIPTION
## Summary
- add reusable orientation gizmo implementation
- render gizmo in vertexcolored cube demo
- hook gizmo into build system

## Testing
- `autoreconf -i && ./configure && make check`

------
https://chatgpt.com/codex/tasks/task_e_6869625384c4832285a024d8e08997fc