### PR TITLE
Add orientation gizmo overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(powergl
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
     src/rendering/grid.c
+    src/rendering/orientation_gizmo.c
     src/ui/scene_hierarchy.c
     src/ui/nuklear_impl.c
     src/math/mat4x4.c

--- a/src/rendering/Makefile.am
+++ b/src/rendering/Makefile.am
@@ -10,7 +10,8 @@ libpowerglrendering_la_HEADERS = \
 	dae2object.h \
         objectlibrary.h \
         3dtext.h \
-        grid.h
+        grid.h \
+        orientation_gizmo.h
 libpowerglrendering_la_LDFLAGS = -no-undefined
 libpowerglrendering_la_SOURCES = \
         object.c \
@@ -19,7 +20,8 @@ libpowerglrendering_la_SOURCES = \
         dae2object.c \
         objectlibrary.c \
         3dtext.c \
-        grid.c
+        grid.c \
+        orientation_gizmo.c
 libpowerglrendering_la_LIBADD = $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/src/rendering/orientation_gizmo.c
+++ b/src/rendering/orientation_gizmo.c
@@ -1,0 +1,52 @@
+#include "orientation_gizmo.h"
+#include <string.h>
+
+void powergl_orientation_gizmo_create(powergl_object *obj, float size)
+{
+    if(!obj)
+        return;
+    memset(obj, 0, sizeof(*obj));
+    powergl_transform_reset(&obj->transform);
+
+    obj->geometry.visible_flag = 1;
+    obj->geometry.primitive_type = GL_LINES;
+    obj->geometry.vertex = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.n_vertex = 6;
+    obj->geometry.vertex_flag = 1;
+    obj->geometry.triangles.color = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.triangles.n_color = 6;
+    obj->geometry.triangles.color_flag = 1;
+
+    /* X axis (red) */
+    obj->geometry.vertex[0] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[1] = (powergl_vec3){size, 0.0f, 0.0f};
+    obj->geometry.triangles.color[0] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[1] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+
+    /* Y axis (green) */
+    obj->geometry.vertex[2] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[3] = (powergl_vec3){0.0f, size, 0.0f};
+    obj->geometry.triangles.color[2] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[3] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+
+    /* Z axis (blue - forward is -Z in OpenGL default) */
+    obj->geometry.vertex[4] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[5] = (powergl_vec3){0.0f, 0.0f, -size};
+    obj->geometry.triangles.color[4] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+    obj->geometry.triangles.color[5] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+}
+
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam)
+{
+    if(!obj || !cam)
+        return;
+    powergl_mat4 view = cam->camera.view;
+    view.c[3].r[0] = 0.0f;
+    view.c[3].r[1] = 0.0f;
+    view.c[3].r[2] = 0.0f;
+    powergl_mat4 proj = powergl_mat4_perspectiveRH(powergl_float_to_radians(45.0f),
+                                                   1.0f, cam->camera.znear, cam->camera.zfar);
+    obj->transform.mvp = powergl_mat4_mul(proj, powergl_mat4_mul(view, obj->transform.world));
+    obj->transform.mvp_flag = 1;
+}
+

--- a/src/rendering/orientation_gizmo.h
+++ b/src/rendering/orientation_gizmo.h
@@ -1,0 +1,10 @@
+#ifndef _powergl_orientation_gizmo_h
+#define _powergl_orientation_gizmo_h
+
+#include "object.h"
+
+/* Build an XYZ orientation gizmo with the given axis length. */
+void powergl_orientation_gizmo_create(powergl_object *obj, float size);
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam);
+
+#endif

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -11,7 +11,9 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
 #include "src/rendering/pipeline.h"
+#include "src/math/mat4x4.h"
 #include "src/ui/scene_hierarchy.h"
 #include "src/png/png_loader.h"
 
@@ -22,7 +24,10 @@ static struct nk_context *nkctx;
 
 static powergl_object *cube;
 static powergl_object grid;
-static powergl_object *object_list[2];
+static powergl_object gizmo;
+static powergl_object *main_objects[2];
+static powergl_object *pipeline_objects[3];
+static powergl_object *gizmo_objects[1];
 static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
@@ -33,13 +38,24 @@ static void scene_create(powergl_visualscene *scene){
     scene->main_camera = powergl_scene_find(scene, "Camera");
     if(!scene->main_camera)
         scene->main_camera = powergl_camera_default();
+
     cube = powergl_scene_find(scene, "Cube");
-    object_list[0] = cube;
+    main_objects[0] = cube;
     powergl_grid_create(&grid, 10);
-    object_list[1] = &grid;
+    main_objects[1] = &grid;
+
+    powergl_orientation_gizmo_create(&gizmo, 1.0f);
+    gizmo_objects[0] = &gizmo;
+
+
     if(cube)
         cube->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
+
+    pipeline_objects[0] = cube;
+    pipeline_objects[1] = &grid;
+    pipeline_objects[2] = &gizmo;
+
+    powergl_pipeline3_create(&scene->pipeline3, pipeline_objects, 3);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -57,8 +73,18 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_object_update_mvp(cube, scene->main_camera);
         powergl_object_update_mvp(&grid, scene->main_camera);
         size_t count = powergl_enable_grid ? 2 : 1;
-        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
+        powergl_pipeline3_render(&scene->pipeline3, main_objects, count);
         scene->main_camera->camera.vp_flag = 0;
+
+        /* draw orientation gizmo */
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        GLint vp[4];
+        glGetIntegerv(GL_VIEWPORT, vp);
+        glDisable(GL_DEPTH_TEST);
+        glViewport(vp[2]-100, vp[3]-100, 100, 100);
+        powergl_pipeline3_render(&scene->pipeline3, gizmo_objects, 1);
+        glViewport(vp[0], vp[1], vp[2], vp[3]);
+        glEnable(GL_DEPTH_TEST);
     }
 
 


### PR DESCRIPTION
## Summary
- add orientation gizmo utility for XYZ axis lines
- compile and link orientation gizmo sources
- draw orientation axes in the vertex-colored cube demo
- **update** orientation gizmo to follow main camera without a separate camera

## Testing
- `autoreconf -i`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6869625384c4832285a024d8e08997fc