### PR TITLE
Add orientation gizmo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(powergl
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
     src/rendering/grid.c
+    src/rendering/orientation_gizmo.c
     src/ui/scene_hierarchy.c
     src/ui/nuklear_impl.c
     src/math/mat4x4.c

--- a/src/rendering/Makefile.am
+++ b/src/rendering/Makefile.am
@@ -10,7 +10,8 @@ libpowerglrendering_la_HEADERS = \
 	dae2object.h \
         objectlibrary.h \
         3dtext.h \
-        grid.h
+        grid.h \
+        orientation_gizmo.h
 libpowerglrendering_la_LDFLAGS = -no-undefined
 libpowerglrendering_la_SOURCES = \
         object.c \
@@ -19,7 +20,8 @@ libpowerglrendering_la_SOURCES = \
         dae2object.c \
         objectlibrary.c \
         3dtext.c \
-        grid.c
+        grid.c \
+        orientation_gizmo.c
 libpowerglrendering_la_LIBADD = $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/src/rendering/orientation_gizmo.c
+++ b/src/rendering/orientation_gizmo.c
@@ -1,0 +1,82 @@
+#include "orientation_gizmo.h"
+#include "../math/mat4x4.h"
+#include <string.h>
+
+void powergl_orientation_gizmo_create(powergl_object *obj, float size)
+{
+    if(!obj)
+        return;
+    memset(obj, 0, sizeof(*obj));
+    powergl_transform_reset(&obj->transform);
+
+    obj->geometry.visible_flag = 1;
+    obj->geometry.primitive_type = GL_LINES;
+    obj->geometry.vertex = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.n_vertex = 6;
+    obj->geometry.vertex_flag = 1;
+    obj->geometry.triangles.color = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.triangles.n_color = 6;
+    obj->geometry.triangles.color_flag = 1;
+
+    obj->geometry.vertex[0] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[1] = (powergl_vec3){size, 0.0f, 0.0f};
+    obj->geometry.vertex[2] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[3] = (powergl_vec3){0.0f, size, 0.0f};
+    obj->geometry.vertex[4] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[5] = (powergl_vec3){0.0f, 0.0f, size};
+
+    obj->geometry.triangles.color[0] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[1] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[2] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[3] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[4] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+    obj->geometry.triangles.color[5] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+}
+
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam)
+{
+    if(!obj || !cam)
+        return;
+
+    powergl_vec3 right = {cam->transform.world.c[0].x,
+                          cam->transform.world.c[0].y,
+                          cam->transform.world.c[0].z};
+    powergl_vec3 up = {cam->transform.world.c[1].x,
+                       cam->transform.world.c[1].y,
+                       cam->transform.world.c[1].z};
+    powergl_vec3 forward = {cam->transform.world.c[2].x,
+                            cam->transform.world.c[2].y,
+                            cam->transform.world.c[2].z};
+
+    powergl_vec3 pos = cam->transform.location;
+    pos = powergl_vec3_add(pos, powergl_vec3_muls(right, 2.0f));
+    pos = powergl_vec3_add(pos, powergl_vec3_muls(up, 2.0f));
+    pos = powergl_vec3_add(pos, powergl_vec3_muls(forward, -5.0f));
+
+    obj->transform.local = powergl_mat4_ident();
+    obj->transform.local = powergl_mat4_translate(obj->transform.local, pos);
+    obj->transform.matrix_flag = 1;
+    obj->transform.world = obj->transform.local;
+
+    powergl_mat4 view = cam->camera.view;
+    view.c[3].x = 0.0f;
+    view.c[3].y = 0.0f;
+    view.c[3].z = 0.0f;
+    powergl_mat4 vp = powergl_mat4_mul(cam->camera.projection, view);
+    obj->transform.mvp = powergl_mat4_mul(vp, obj->transform.world);
+    obj->transform.mvp_flag = 1;
+}
+
+void powergl_orientation_gizmo_draw(powergl_pipeline3 *ppl, powergl_object *obj)
+{
+    if(!ppl || !obj)
+        return;
+
+    GLint vp[4];
+    glGetIntegerv(GL_VIEWPORT, vp);
+    glViewport(vp[2] - 120, vp[3] - 120, 120, 120);
+    glDisable(GL_DEPTH_TEST);
+    powergl_pipeline3_render(ppl, &obj, 1);
+    glEnable(GL_DEPTH_TEST);
+    glViewport(vp[0], vp[1], vp[2], vp[3]);
+}

--- a/src/rendering/orientation_gizmo.h
+++ b/src/rendering/orientation_gizmo.h
@@ -1,0 +1,10 @@
+#ifndef POWERGL_ORIENTATION_GIZMO_H
+#define POWERGL_ORIENTATION_GIZMO_H
+#include "object.h"
+#include "pipeline.h"
+
+void powergl_orientation_gizmo_create(powergl_object *obj, float size);
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam);
+void powergl_orientation_gizmo_draw(powergl_pipeline3 *ppl, powergl_object *obj);
+
+#endif

--- a/tests/animatedcube_demo.c
+++ b/tests/animatedcube_demo.c
@@ -11,6 +11,7 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
 
@@ -21,7 +22,8 @@ static struct nk_context *nkctx;
 
 static powergl_object *cube;
 static powergl_object grid;
-static powergl_object *object_list[2];
+static powergl_object gizmo;
+static powergl_object *object_list[3];
 static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
@@ -38,9 +40,11 @@ static void scene_create(powergl_visualscene *scene){
     object_list[0] = cube;
     powergl_grid_create(&grid, 10);
     object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo, 1.0f);
+    object_list[2] = &gizmo;
     if(scene->main_camera)
         scene->main_camera->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
+    powergl_pipeline3_create(&scene->pipeline3, object_list, 3);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -61,8 +65,10 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_camera_update(scene->main_camera);
         powergl_object_update_mvp(cube, scene->main_camera);
         powergl_object_update_mvp(&grid, scene->main_camera);
-        size_t count = powergl_enable_grid ? 2 : 1;
-        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline3_render(&scene->pipeline3, object_list, count - 1);
+        powergl_orientation_gizmo_draw(&scene->pipeline3, &gizmo);
         scene->main_camera->camera.vp_flag = 0;
     }
 }

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -11,6 +11,7 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
 #include "src/png/png_loader.h"
@@ -22,7 +23,8 @@ static struct nk_context *nkctx;
 
 static powergl_object *cube;
 static powergl_object grid;
-static powergl_object *object_list[2];
+static powergl_object gizmo;
+static powergl_object *object_list[3];
 static int frame_counter = 0;
 static const int max_frames = 1;
 static int png_mismatch = 0;
@@ -40,9 +42,11 @@ static void scene_create(powergl_visualscene *scene){
     object_list[0] = cube;
     powergl_grid_create(&grid, 10);
     object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo, 1.0f);
+    object_list[2] = &gizmo;
     if(scene->main_camera)
         scene->main_camera->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
+    powergl_pipeline3_create(&scene->pipeline3, object_list, 3);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -59,8 +63,10 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_camera_update(scene->main_camera);
         powergl_object_update_mvp(cube, scene->main_camera);
         powergl_object_update_mvp(&grid, scene->main_camera);
-        size_t count = powergl_enable_grid ? 2 : 1;
-        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline3_render(&scene->pipeline3, object_list, count - 1);
+        powergl_orientation_gizmo_draw(&scene->pipeline3, &gizmo);
         scene->main_camera->camera.vp_flag = 0;
     }
 


### PR DESCRIPTION
## Summary
- add orientation gizmo helper for visualizing camera axes
- render gizmo in the vertexcolored cube and animated cube demos
- build new files in build system

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_686be02806808322a8072cf7db3660a1