### PR TITLE
Add orientation gizmo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(powergl
     src/rendering/objectlibrary.c
     src/rendering/3dtext.c
     src/rendering/grid.c
+    src/rendering/orientation_gizmo.c
     src/ui/scene_hierarchy.c
     src/ui/nuklear_impl.c
     src/math/mat4x4.c

--- a/src/rendering/Makefile.am
+++ b/src/rendering/Makefile.am
@@ -10,7 +10,8 @@ libpowerglrendering_la_HEADERS = \
 	dae2object.h \
         objectlibrary.h \
         3dtext.h \
-        grid.h
+        grid.h \
+        orientation_gizmo.h
 libpowerglrendering_la_LDFLAGS = -no-undefined
 libpowerglrendering_la_SOURCES = \
         object.c \
@@ -19,7 +20,8 @@ libpowerglrendering_la_SOURCES = \
         dae2object.c \
         objectlibrary.c \
         3dtext.c \
-        grid.c
+        grid.c \
+        orientation_gizmo.c
 libpowerglrendering_la_LIBADD = $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/src/rendering/orientation_gizmo.c
+++ b/src/rendering/orientation_gizmo.c
@@ -1,0 +1,56 @@
+#include "orientation_gizmo.h"
+#include <string.h>
+
+void powergl_orientation_gizmo_create(powergl_object *obj, float size)
+{
+    if(!obj)
+        return;
+    memset(obj, 0, sizeof(*obj));
+    powergl_transform_reset(&obj->transform);
+
+    obj->geometry.visible_flag = 1;
+    obj->geometry.primitive_type = GL_LINES;
+    obj->geometry.n_vertex = 6;
+    obj->geometry.vertex = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.vertex_flag = 1;
+    obj->geometry.triangles.color = powergl_resize(NULL, 6, sizeof(powergl_vec3));
+    obj->geometry.triangles.n_color = 6;
+    obj->geometry.triangles.color_flag = 1;
+
+    obj->geometry.vertex[0] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[1] = (powergl_vec3){size, 0.0f, 0.0f};
+    obj->geometry.vertex[2] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[3] = (powergl_vec3){0.0f, size, 0.0f};
+    obj->geometry.vertex[4] = (powergl_vec3){0.0f, 0.0f, 0.0f};
+    obj->geometry.vertex[5] = (powergl_vec3){0.0f, 0.0f, size};
+
+    obj->geometry.triangles.color[0] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[1] = (powergl_vec3){1.0f, 0.0f, 0.0f};
+    obj->geometry.triangles.color[2] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[3] = (powergl_vec3){0.0f, 1.0f, 0.0f};
+    obj->geometry.triangles.color[4] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+    obj->geometry.triangles.color[5] = (powergl_vec3){0.0f, 0.0f, 1.0f};
+}
+
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam)
+{
+    if(!obj || !cam)
+        return;
+
+    powergl_mat4 mat = powergl_mat4_ident();
+    mat.c[0].x = 0.1f;
+    mat.c[1].y = 0.1f;
+    mat.c[2].z = 0.1f;
+
+    mat = powergl_mat4_rot(mat, cam->transform.rotation_z.w, cam->transform.rotation_z.xyz);
+    mat = powergl_mat4_rot(mat, cam->transform.rotation_y.w, cam->transform.rotation_y.xyz);
+    mat = powergl_mat4_rot(mat, cam->transform.rotation_x.w, cam->transform.rotation_x.xyz);
+
+    mat.c[3].x = 0.8f;
+    mat.c[3].y = 0.8f;
+    mat.c[3].z = 0.0f;
+
+    obj->transform.mvp = mat;
+    obj->transform.mvp_flag = 1;
+}
+

--- a/src/rendering/orientation_gizmo.h
+++ b/src/rendering/orientation_gizmo.h
@@ -1,0 +1,6 @@
+#ifndef _powergl_orientation_gizmo_h
+#define _powergl_orientation_gizmo_h
+#include "object.h"
+void powergl_orientation_gizmo_create(powergl_object *obj, float size);
+void powergl_orientation_gizmo_update(powergl_object *obj, powergl_object *cam);
+#endif

--- a/tests/animatedcube_demo.c
+++ b/tests/animatedcube_demo.c
@@ -11,6 +11,7 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
 
@@ -21,7 +22,8 @@ static struct nk_context *nkctx;
 
 static powergl_object *cube;
 static powergl_object grid;
-static powergl_object *object_list[2];
+static powergl_object gizmo;
+static powergl_object *object_list[3];
 static int frame_counter = 0;
 static const int max_frames = 10;
 static int png_mismatch = 0;
@@ -38,9 +40,11 @@ static void scene_create(powergl_visualscene *scene){
     object_list[0] = cube;
     powergl_grid_create(&grid, 10);
     object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo, 1.0f);
+    object_list[2] = &gizmo;
     if(scene->main_camera)
         scene->main_camera->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
+    powergl_pipeline3_create(&scene->pipeline3, object_list, 3);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -61,8 +65,16 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_camera_update(scene->main_camera);
         powergl_object_update_mvp(cube, scene->main_camera);
         powergl_object_update_mvp(&grid, scene->main_camera);
-        size_t count = powergl_enable_grid ? 2 : 1;
-        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+
+        powergl_object *draw_list[3];
+        size_t idx = 0;
+        draw_list[idx++] = cube;
+        if(powergl_enable_grid)
+            draw_list[idx++] = &grid;
+        draw_list[idx++] = &gizmo;
+
+        powergl_pipeline3_render(&scene->pipeline3, draw_list, idx);
         scene->main_camera->camera.vp_flag = 0;
     }
 }

--- a/tests/vertexcoloredcube_demo.c
+++ b/tests/vertexcoloredcube_demo.c
@@ -11,6 +11,7 @@
 #include "src/rendering/visualscene.h"
 #include "src/rendering/object.h"
 #include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
 #include "src/rendering/pipeline.h"
 #include "src/ui/scene_hierarchy.h"
 #include "src/png/png_loader.h"
@@ -22,7 +23,8 @@ static struct nk_context *nkctx;
 
 static powergl_object *cube;
 static powergl_object grid;
-static powergl_object *object_list[2];
+static powergl_object gizmo;
+static powergl_object *object_list[3];
 static int frame_counter = 0;
 static const int max_frames = 1;
 static int png_mismatch = 0;
@@ -40,9 +42,11 @@ static void scene_create(powergl_visualscene *scene){
     object_list[0] = cube;
     powergl_grid_create(&grid, 10);
     object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo, 1.0f);
+    object_list[2] = &gizmo;
     if(scene->main_camera)
         scene->main_camera->event_flag = 1;
-    powergl_pipeline3_create(&scene->pipeline3, object_list, 2);
+    powergl_pipeline3_create(&scene->pipeline3, object_list, 3);
 }
 
 static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
@@ -59,8 +63,16 @@ static void scene_run(powergl_visualscene *scene, float dt){
         powergl_camera_update(scene->main_camera);
         powergl_object_update_mvp(cube, scene->main_camera);
         powergl_object_update_mvp(&grid, scene->main_camera);
-        size_t count = powergl_enable_grid ? 2 : 1;
-        powergl_pipeline3_render(&scene->pipeline3, object_list, count);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+
+        powergl_object *draw_list[3];
+        size_t idx = 0;
+        draw_list[idx++] = cube;
+        if(powergl_enable_grid)
+            draw_list[idx++] = &grid;
+        draw_list[idx++] = &gizmo;
+
+        powergl_pipeline3_render(&scene->pipeline3, draw_list, idx);
         scene->main_camera->camera.vp_flag = 0;
     }
 


### PR DESCRIPTION
## Summary
- add a small orientation gizmo that follows the main camera
- hook orientation gizmo into demos
- build orientation gizmo via build files

## Testing
- `autoreconf -i`
- `./configure`
- `make check` *(fails: run_vertexcoloredcube_headless.sh)*

------
https://chatgpt.com/codex/tasks/task_e_686be02806808322a8072cf7db3660a1