### PR TITLE
Add intersection unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,12 @@ target_link_libraries(gtest_collada PRIVATE powergl GTest::gtest_main)
 
 gtest_discover_tests(gtest_collada)
 
+add_executable(gtest_intersect gtest_intersect.cpp)
+target_compile_definitions(gtest_intersect PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(gtest_intersect PRIVATE powergl GTest::gtest_main)
+
+gtest_discover_tests(gtest_intersect)
+
 add_executable(vertexcoloredcube_demo vertexcoloredcube_demo.c)
 target_compile_definitions(vertexcoloredcube_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(vertexcoloredcube_demo PRIVATE powergl)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,8 +8,8 @@ AM_CXXFLAGS = -std=c++17 $(CODE_COVERAGE_CXXFLAGS)
 AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
 
-check_PROGRAMS = gtest_math gtest_collada vertexcoloredcube_demo animatedcube_demo
-TESTS = gtest_math gtest_collada run_vertexcoloredcube_headless.sh
+check_PROGRAMS = gtest_math gtest_collada gtest_intersect vertexcoloredcube_demo animatedcube_demo
+TESTS = gtest_math gtest_collada gtest_intersect run_vertexcoloredcube_headless.sh
 
 gtest_math_SOURCES = gtest_math.cpp
 
@@ -20,6 +20,10 @@ gtest_collada_LDADD = \
     $(top_builddir)/src/collada/libpowerglcollada.la \
     $(top_builddir)/src/libpowergl.la \
     $(GTEST_LIBS) -lm $(CODE_COVERAGE_LIBS)
+
+gtest_intersect_SOURCES = gtest_intersect.cpp
+gtest_intersect_LDADD = \
+    $(top_builddir)/src/math/libpowerglmath.la $(GTEST_LIBS) -lm $(CODE_COVERAGE_LIBS)
 
 vertexcoloredcube_demo_SOURCES = vertexcoloredcube_demo.c
 vertexcoloredcube_demo_LDADD = \

--- a/tests/gtest_intersect.cpp
+++ b/tests/gtest_intersect.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+extern "C" {
+#include "src/math/intersect.h"
+}
+
+TEST(Intersect, RayTriangleBasic){
+    powergl_vec3 mesh[3] = {
+        {-1.0f, -1.0f, 0.0f},
+        { 1.0f, -1.0f, 0.0f},
+        { 0.0f,  1.0f, 0.0f}
+    };
+    powergl_mat4 mvp = powergl_mat4_ident();
+    powergl_vec2 event = {50.0f, 50.0f};
+    powergl_vec4 vp = {0.0f, 0.0f, 100.0f, 100.0f};
+    powergl_vec3 out;
+    int hit = powergl_intersect_ray_tri_mesh(mesh, 3, mvp, event, vp, &out, 0);
+    ASSERT_EQ(hit, 1);
+    EXPECT_NEAR(out.x, 0.25f, 1e-5f);
+    EXPECT_NEAR(out.y, 0.5f, 1e-5f);
+    EXPECT_NEAR(out.z, 1.0f, 1e-5f);
+}
+
+TEST(Intersect, CullBackface){
+    powergl_vec3 mesh[3] = {
+        {-1.0f, -1.0f, 0.0f},
+        { 1.0f, -1.0f, 0.0f},
+        { 0.0f,  1.0f, 0.0f}
+    };
+    powergl_mat4 mvp = powergl_mat4_ident();
+    powergl_vec2 event = {50.0f, 50.0f};
+    powergl_vec4 vp = {0.0f, 0.0f, 100.0f, 100.0f};
+    powergl_vec3 out;
+    int hit = powergl_intersect_ray_tri_mesh(mesh, 3, mvp, event, vp, &out, 1);
+    ASSERT_EQ(hit, 0);
+}
+
+int main(int argc, char **argv){
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- increase coverage by adding new intersection tests
- hook new tests into build system for Automake and CMake

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6875089fecac8322b68140d2515471b9