### PR TITLE
Add demos for shading techniques

### DIFF
--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -698,3 +698,301 @@ void powergl_pipeline_create(powergl_pipeline *ppl, powergl_object **objs, size_
   return;
 }
 
+void powergl_pipeline_flat_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  /*vertex shader input attribute specs*/
+  /*vertex input*/
+  ppl->vis.index = 0;
+  ppl->vis.size = 3;
+  ppl->vis.type = GL_FLOAT;
+  ppl->vis.normalized = GL_FALSE;
+  ppl->vis.stride = 0;
+  ppl->vis.offset = 0;
+
+  /* normal input */
+  ppl->nis.index = 1;
+  ppl->nis.size = 3;
+  ppl->nis.type = GL_FLOAT;
+  ppl->nis.normalized = GL_FALSE;
+  ppl->nis.stride = 0;
+  ppl->nis.offset = 0;
+
+  /* color input */
+  ppl->cis.index = 2;
+  ppl->cis.size = 3;
+  ppl->cis.type = GL_FLOAT;
+  ppl->cis.normalized = GL_FALSE;
+  ppl->cis.stride = 0;
+  ppl->cis.offset = 0;
+
+  /*shader compiler input specs*/
+  const GLchar *const vsrc[] = {
+    "#version 330 core\n"
+    "layout(location = 0) in vec3 vPosition;\n"
+    "layout(location = 1) in vec3 vNormal;\n"
+    "layout(location = 2) in vec3 vColor;\n"
+    "out flat vec3 normalToFs;\n"
+    "out flat vec3 colorToFs;\n"
+    "uniform mat4 mvp;\n"
+    "void main(){\n"
+    "  normalToFs = vNormal;\n"
+    "  colorToFs = vColor;\n"
+    "  gl_Position = mvp * vec4(vPosition,1.0);\n"
+    "}"
+  };
+  const GLchar *const fsrc[] = {
+    "#version 330 core\n"
+    "in flat vec3 normalToFs;\n"
+    "in flat vec3 colorToFs;\n"
+    "out vec4 fColor;\n"
+    "uniform vec3 lightColor;\n"
+    "uniform vec3 lightDir;\n"
+    "void main(){\n"
+    "  vec3 ambient = vec3(0.1,0.1,0.1);\n"
+    "  float diff = max(dot(normalize(normalToFs), normalize(-lightDir)),0.0);\n"
+    "  vec3 result = (ambient + diff * lightColor) * colorToFs;\n"
+    "  fColor = vec4(result,1.0);\n"
+    "}"
+  };
+
+  ppl->vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(ppl->vs, 1, vsrc, NULL);
+  glCompileShader(ppl->vs);
+  ppl->fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(ppl->fs, 1, fsrc, NULL);
+  glCompileShader(ppl->fs);
+  ppl->gp = glCreateProgram();
+  glAttachShader(ppl->gp, ppl->vs);
+  glAttachShader(ppl->gp, ppl->fs);
+  glLinkProgram(ppl->gp);
+  glUseProgram(ppl->gp);
+  ppl->uni_matrix = glGetUniformLocation(ppl->gp, "mvp");
+  ppl->uni_light_color = glGetUniformLocation(ppl->gp, "lightColor");
+  ppl->uni_light_dir = glGetUniformLocation(ppl->gp, "lightDir");
+  ppl->uni_sampler = -1;
+
+  powergl_pipeline_create_objects(ppl, objs, n_obj);
+}
+
+void powergl_pipeline_gouraud_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  /*vertex shader input attribute specs*/
+  /*vertex input*/
+  ppl->vis.index = 0;
+  ppl->vis.size = 3;
+  ppl->vis.type = GL_FLOAT;
+  ppl->vis.normalized = GL_FALSE;
+  ppl->vis.stride = 0;
+  ppl->vis.offset = 0;
+
+  /* normal input */
+  ppl->nis.index = 1;
+  ppl->nis.size = 3;
+  ppl->nis.type = GL_FLOAT;
+  ppl->nis.normalized = GL_FALSE;
+  ppl->nis.stride = 0;
+  ppl->nis.offset = 0;
+
+  /* color input */
+  ppl->cis.index = 2;
+  ppl->cis.size = 3;
+  ppl->cis.type = GL_FLOAT;
+  ppl->cis.normalized = GL_FALSE;
+  ppl->cis.stride = 0;
+  ppl->cis.offset = 0;
+
+  const GLchar *const vsrc[] = {
+    "#version 330 core\n"
+    "layout(location = 0) in vec3 vPosition;\n"
+    "layout(location = 1) in vec3 vNormal;\n"
+    "layout(location = 2) in vec3 vColor;\n"
+    "out vec3 colorToFs;\n"
+    "uniform mat4 mvp;\n"
+    "uniform vec3 lightColor;\n"
+    "uniform vec3 lightDir;\n"
+    "void main(){\n"
+    "  vec3 ambient = vec3(0.1,0.1,0.1);\n"
+    "  float diff = max(dot(normalize(vNormal), normalize(-lightDir)),0.0);\n"
+    "  colorToFs = (ambient + diff * lightColor) * vColor;\n"
+    "  gl_Position = mvp * vec4(vPosition,1.0);\n"
+    "}"
+  };
+  const GLchar *const fsrc[] = {
+    "#version 330 core\n"
+    "in vec3 colorToFs;\n"
+    "out vec4 fColor;\n"
+    "void main(){\n"
+    "  fColor = vec4(colorToFs,1.0);\n"
+    "}"
+  };
+
+  ppl->vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(ppl->vs, 1, vsrc, NULL);
+  glCompileShader(ppl->vs);
+  ppl->fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(ppl->fs, 1, fsrc, NULL);
+  glCompileShader(ppl->fs);
+  ppl->gp = glCreateProgram();
+  glAttachShader(ppl->gp, ppl->vs);
+  glAttachShader(ppl->gp, ppl->fs);
+  glLinkProgram(ppl->gp);
+  glUseProgram(ppl->gp);
+  ppl->uni_matrix = glGetUniformLocation(ppl->gp, "mvp");
+  ppl->uni_light_color = glGetUniformLocation(ppl->gp, "lightColor");
+  ppl->uni_light_dir = glGetUniformLocation(ppl->gp, "lightDir");
+  ppl->uni_sampler = -1;
+
+  powergl_pipeline_create_objects(ppl, objs, n_obj);
+}
+
+void powergl_pipeline_lambert_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  /*vertex shader input attribute specs*/
+  /*vertex input*/
+  ppl->vis.index = 0;
+  ppl->vis.size = 3;
+  ppl->vis.type = GL_FLOAT;
+  ppl->vis.normalized = GL_FALSE;
+  ppl->vis.stride = 0;
+  ppl->vis.offset = 0;
+
+  /* normal input */
+  ppl->nis.index = 1;
+  ppl->nis.size = 3;
+  ppl->nis.type = GL_FLOAT;
+  ppl->nis.normalized = GL_FALSE;
+  ppl->nis.stride = 0;
+  ppl->nis.offset = 0;
+
+  /* color input */
+  ppl->cis.index = 2;
+  ppl->cis.size = 3;
+  ppl->cis.type = GL_FLOAT;
+  ppl->cis.normalized = GL_FALSE;
+  ppl->cis.stride = 0;
+  ppl->cis.offset = 0;
+
+  const GLchar *const vsrc[] = {
+    "#version 330 core\n"
+    "layout(location = 0) in vec3 vPosition;\n"
+    "layout(location = 1) in vec3 vNormal;\n"
+    "layout(location = 2) in vec3 vColor;\n"
+    "out vec3 normalToFs;\n"
+    "out vec3 colorToFs;\n"
+    "uniform mat4 mvp;\n"
+    "void main(){\n"
+    "  normalToFs = vNormal;\n"
+    "  colorToFs = vColor;\n"
+    "  gl_Position = mvp * vec4(vPosition,1.0);\n"
+    "}"
+  };
+  const GLchar *const fsrc[] = {
+    "#version 330 core\n"
+    "in vec3 normalToFs;\n"
+    "in vec3 colorToFs;\n"
+    "out vec4 fColor;\n"
+    "uniform vec3 lightColor;\n"
+    "uniform vec3 lightDir;\n"
+    "void main(){\n"
+    "  vec3 ambient = vec3(0.1,0.1,0.1);\n"
+    "  float diff = max(dot(normalize(normalToFs), normalize(-lightDir)),0.0);\n"
+    "  vec3 result = (ambient + diff * lightColor) * colorToFs;\n"
+    "  fColor = vec4(result,1.0);\n"
+    "}"
+  };
+
+  ppl->vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(ppl->vs, 1, vsrc, NULL);
+  glCompileShader(ppl->vs);
+  ppl->fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(ppl->fs, 1, fsrc, NULL);
+  glCompileShader(ppl->fs);
+  ppl->gp = glCreateProgram();
+  glAttachShader(ppl->gp, ppl->vs);
+  glAttachShader(ppl->gp, ppl->fs);
+  glLinkProgram(ppl->gp);
+  glUseProgram(ppl->gp);
+  ppl->uni_matrix = glGetUniformLocation(ppl->gp, "mvp");
+  ppl->uni_light_color = glGetUniformLocation(ppl->gp, "lightColor");
+  ppl->uni_light_dir = glGetUniformLocation(ppl->gp, "lightDir");
+  ppl->uni_sampler = -1;
+
+  powergl_pipeline_create_objects(ppl, objs, n_obj);
+}
+
+void powergl_pipeline_blinnphong_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  /*vertex shader input attribute specs*/
+  /*vertex input*/
+  ppl->vis.index = 0;
+  ppl->vis.size = 3;
+  ppl->vis.type = GL_FLOAT;
+  ppl->vis.normalized = GL_FALSE;
+  ppl->vis.stride = 0;
+  ppl->vis.offset = 0;
+
+  /* normal input */
+  ppl->nis.index = 1;
+  ppl->nis.size = 3;
+  ppl->nis.type = GL_FLOAT;
+  ppl->nis.normalized = GL_FALSE;
+  ppl->nis.stride = 0;
+  ppl->nis.offset = 0;
+
+  /* color input */
+  ppl->cis.index = 2;
+  ppl->cis.size = 3;
+  ppl->cis.type = GL_FLOAT;
+  ppl->cis.normalized = GL_FALSE;
+  ppl->cis.stride = 0;
+  ppl->cis.offset = 0;
+
+  const GLchar *const vsrc[] = {
+    "#version 330 core\n"
+    "layout(location = 0) in vec3 vPosition;\n"
+    "layout(location = 1) in vec3 vNormal;\n"
+    "layout(location = 2) in vec3 vColor;\n"
+    "out vec3 normalToFs;\n"
+    "out vec3 colorToFs;\n"
+    "uniform mat4 mvp;\n"
+    "void main(){\n"
+    "  normalToFs = vNormal;\n"
+    "  colorToFs = vColor;\n"
+    "  gl_Position = mvp * vec4(vPosition,1.0);\n"
+    "}"
+  };
+  const GLchar *const fsrc[] = {
+    "#version 330 core\n"
+    "in vec3 normalToFs;\n"
+    "in vec3 colorToFs;\n"
+    "out vec4 fColor;\n"
+    "uniform vec3 lightColor;\n"
+    "uniform vec3 lightDir;\n"
+    "void main(){\n"
+    "  vec3 ambient = vec3(0.1,0.1,0.1);\n"
+    "  vec3 norm = normalize(normalToFs);\n"
+    "  vec3 ld = normalize(-lightDir);\n"
+    "  float diff = max(dot(norm, ld), 0.0);\n"
+    "  vec3 viewDir = vec3(0.0,0.0,1.0);\n"
+    "  vec3 halfDir = normalize(ld + viewDir);\n"
+    "  float spec = pow(max(dot(norm, halfDir), 0.0), 32.0);\n"
+    "  vec3 result = (ambient + (diff + spec) * lightColor) * colorToFs;\n"
+    "  fColor = vec4(result,1.0);\n"
+    "}"
+  };
+
+  ppl->vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(ppl->vs, 1, vsrc, NULL);
+  glCompileShader(ppl->vs);
+  ppl->fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(ppl->fs, 1, fsrc, NULL);
+  glCompileShader(ppl->fs);
+  ppl->gp = glCreateProgram();
+  glAttachShader(ppl->gp, ppl->vs);
+  glAttachShader(ppl->gp, ppl->fs);
+  glLinkProgram(ppl->gp);
+  glUseProgram(ppl->gp);
+  ppl->uni_matrix = glGetUniformLocation(ppl->gp, "mvp");
+  ppl->uni_light_color = glGetUniformLocation(ppl->gp, "lightColor");
+  ppl->uni_light_dir = glGetUniformLocation(ppl->gp, "lightDir");
+  ppl->uni_sampler = -1;
+
+  powergl_pipeline_create_objects(ppl, objs, n_obj);
+}
+

--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -123,9 +123,7 @@ static void render2(powergl_pipeline2 *ppl, powergl_object **objs, size_t n_obje
       continue;
     }
       
-    if(last_obj != objs[i]){
-      glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
-    } else if(obj->transform.mvp_flag == 1){      
+    if(last_obj != objs[i] || obj->transform.mvp_flag == 1 || ppl->forceUpdate){
       glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
       obj->transform.mvp_flag = 0;
     }
@@ -180,12 +178,9 @@ static void render(powergl_pipeline *ppl, powergl_object **objs, size_t n_object
 
 
       
-    if(last_obj != objs[i]){
+    if(last_obj != objs[i] || obj->transform.mvp_flag == 1 || ppl->forceUpdate){
       glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
       glUniform1i(ppl->uni_sampler, 0);
-
-    } else if(obj->transform.mvp_flag == 1){      
-      glUniformMatrix4fv(ppl->uni_matrix, 1, GL_FALSE, obj->transform.mvp.data);
       obj->transform.mvp_flag = 0;
     }
 
@@ -270,7 +265,7 @@ void powergl_pipeline3_render(powergl_pipeline3 *ppl, powergl_object **objs, siz
 
 void powergl_pipeline2_render(powergl_pipeline2 *ppl, powergl_object **objs, size_t n_object) {
 
-    if(ppl!=last_ppl2){
+    if(ppl!=last_ppl2 || ppl->forceUpdate){
 
       // restore uniforms
       glUseProgram(ppl->gp);
@@ -292,7 +287,7 @@ void powergl_pipeline2_render(powergl_pipeline2 *ppl, powergl_object **objs, siz
 
 void powergl_pipeline_render(powergl_pipeline *ppl, powergl_object **objs, size_t n_object, powergl_object *main_light) {
 
-    if(ppl!=last_ppl){
+    if(ppl!=last_ppl || ppl->forceUpdate){
 
       // restore uniforms
       glUseProgram(ppl->gp);
@@ -555,6 +550,7 @@ void powergl_pipeline3_create(powergl_pipeline3 *ppl, powergl_object **objs, siz
 }
 
 void powergl_pipeline2_create(powergl_pipeline2 *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   
   /*vertex shader input attibute specs*/
   
@@ -609,6 +605,7 @@ void powergl_pipeline2_create(powergl_pipeline2 *ppl, powergl_object **objs, siz
 }
 
 void powergl_pipeline_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   
   /*vertex shader input attibute specs*/
   
@@ -699,6 +696,7 @@ void powergl_pipeline_create(powergl_pipeline *ppl, powergl_object **objs, size_
 }
 
 void powergl_pipeline_flat_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   /*vertex shader input attribute specs*/
   /*vertex input*/
   ppl->vis.index = 0;
@@ -774,6 +772,7 @@ void powergl_pipeline_flat_create(powergl_pipeline *ppl, powergl_object **objs, 
 }
 
 void powergl_pipeline_gouraud_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   /*vertex shader input attribute specs*/
   /*vertex input*/
   ppl->vis.index = 0;
@@ -844,6 +843,7 @@ void powergl_pipeline_gouraud_create(powergl_pipeline *ppl, powergl_object **obj
 }
 
 void powergl_pipeline_lambert_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   /*vertex shader input attribute specs*/
   /*vertex input*/
   ppl->vis.index = 0;
@@ -918,6 +918,7 @@ void powergl_pipeline_lambert_create(powergl_pipeline *ppl, powergl_object **obj
 }
 
 void powergl_pipeline_blinnphong_create(powergl_pipeline *ppl, powergl_object **objs, size_t n_obj) {
+  ppl->forceUpdate = 0;
   /*vertex shader input attribute specs*/
   /*vertex input*/
   ppl->vis.index = 0;

--- a/src/rendering/pipeline.h
+++ b/src/rendering/pipeline.h
@@ -34,6 +34,7 @@ struct powergl_pipeline_t {
   GLint uni_light_color;
   GLint uni_light_dir;
   GLint uni_sampler;
+  int forceUpdate;
 };
 
 struct powergl_pipeline2_t {
@@ -42,6 +43,7 @@ struct powergl_pipeline2_t {
   GLuint fs;
   GLuint gp;
   GLint uni_matrix;
+  int forceUpdate;
 };
 
 struct powergl_pipeline3_t {

--- a/src/rendering/pipeline.h
+++ b/src/rendering/pipeline.h
@@ -69,6 +69,11 @@ void powergl_pipeline2_render(powergl_pipeline2 *, powergl_object **, size_t);
 void powergl_pipeline3_create(powergl_pipeline3 *, powergl_object **objs, size_t n_obj);
 void powergl_pipeline3_render(powergl_pipeline3 *, powergl_object **, size_t);
 
+void powergl_pipeline_flat_create(powergl_pipeline *, powergl_object **objs, size_t n_obj);
+void powergl_pipeline_gouraud_create(powergl_pipeline *, powergl_object **objs, size_t n_obj);
+void powergl_pipeline_lambert_create(powergl_pipeline *, powergl_object **objs, size_t n_obj);
+void powergl_pipeline_blinnphong_create(powergl_pipeline *, powergl_object **objs, size_t n_obj);
+
 /* Set to 0 to disable drawing selection outlines */
 extern int powergl_enable_outline;
 /* Set to 0 to disable drawing the grid */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,22 @@ add_executable(vertexcoloredcube_demo vertexcoloredcube_demo.c)
 target_compile_definitions(vertexcoloredcube_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(vertexcoloredcube_demo PRIVATE powergl)
 
+add_executable(flat_demo flat_demo.c)
+target_compile_definitions(flat_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(flat_demo PRIVATE powergl)
+
+add_executable(gouraud_demo gouraud_demo.c)
+target_compile_definitions(gouraud_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(gouraud_demo PRIVATE powergl)
+
+add_executable(lambert_demo lambert_demo.c)
+target_compile_definitions(lambert_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(lambert_demo PRIVATE powergl)
+
+add_executable(blinnphong_demo blinnphong_demo.c)
+target_compile_definitions(blinnphong_demo PRIVATE TEST_SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(blinnphong_demo PRIVATE powergl)
+
 add_test(NAME vertexcoloredcube_headless
           COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_vertexcoloredcube_headless.sh
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,8 @@ AM_CXXFLAGS = -std=c++17 $(CODE_COVERAGE_CXXFLAGS)
 AM_CFLAGS = $(CODE_COVERAGE_CFLAGS)
 CODE_COVERAGE_LCOV_OPTIONS = --ignore-errors mismatch
 
-check_PROGRAMS = gtest_math gtest_collada gtest_intersect vertexcoloredcube_demo animatedcube_demo
+check_PROGRAMS = gtest_math gtest_collada gtest_intersect vertexcoloredcube_demo animatedcube_demo \
+    flat_demo gouraud_demo lambert_demo blinnphong_demo
 TESTS = gtest_math gtest_collada gtest_intersect run_vertexcoloredcube_headless.sh
 
 gtest_math_SOURCES = gtest_math.cpp
@@ -31,6 +32,22 @@ vertexcoloredcube_demo_LDADD = \
 
 animatedcube_demo_SOURCES = animatedcube_demo.c
 animatedcube_demo_LDADD = \
+    $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
+
+flat_demo_SOURCES = flat_demo.c
+flat_demo_LDADD = \
+    $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
+
+gouraud_demo_SOURCES = gouraud_demo.c
+gouraud_demo_LDADD = \
+    $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
+
+lambert_demo_SOURCES = lambert_demo.c
+lambert_demo_LDADD = \
+    $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
+
+blinnphong_demo_SOURCES = blinnphong_demo.c
+blinnphong_demo_LDADD = \
     $(top_builddir)/src/libpowergl.la -lm $(CODE_COVERAGE_LIBS)
 
 include $(top_srcdir)/aminclude_static.am

--- a/tests/blinnphong_demo.c
+++ b/tests/blinnphong_demo.c
@@ -1,0 +1,144 @@
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+#include <string.h>
+#include <stdlib.h>
+#include "src/event.h"
+#include "third_party/nuklear/nuklear.h"
+#include "third_party/nuklear/nuklear_sdl_gl3.h"
+#include "src/window/window.h"
+#include "src/window/headless.h"
+#include "src/rendering/visualscene.h"
+#include "src/rendering/object.h"
+#include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
+#include "src/rendering/pipeline.h"
+#include "src/ui/scene_hierarchy.h"
+#include "src/png/png_loader.h"
+
+#define MAX_VERTEX_MEMORY (512 * 1024)
+#define MAX_ELEMENT_MEMORY (128 * 1024)
+
+static struct nk_context *nkctx;
+
+static powergl_object *cube;
+static powergl_object grid;
+static powergl_object gizmo;
+static powergl_object *object_list[3];
+static int frame_counter = 0;
+static const int max_frames = 1;
+
+static void scene_create(powergl_visualscene *scene){
+    const char *dae = TEST_SRCDIR "/vertexcolored_cube.dae";
+    powergl_scene_build(scene, dae);
+    scene->main_camera = powergl_scene_find(scene, "Camera");
+    if(!scene->main_camera)
+    {
+        scene->main_camera = powergl_camera_default();
+        powergl_scene_add_object(scene, scene->main_camera, NULL);
+    }
+    cube = powergl_scene_find(scene, "Cube");
+    object_list[0] = cube;
+    powergl_grid_create(&grid, 10);
+    object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo);
+    object_list[2] = &gizmo;
+    if(scene->main_camera)
+        scene->main_camera->event_flag = 1;
+    scene->main_light = powergl_scene_find(scene, "Light");
+    powergl_pipeline_blinnphong_create(&scene->pipeline, object_list, 3);
+}
+
+static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
+    powergl_scene_handle_picking(scene, e);
+    if(scene->main_camera)
+        powergl_event_handle(scene->main_camera, e, dt);
+}
+
+static void scene_run(powergl_visualscene *scene, float dt){
+    if(cube && scene->main_camera)
+    {
+        powergl_object_fps_controller(scene->main_camera, dt);
+        powergl_object_update_transform(scene->main_camera, dt);
+        powergl_camera_update(scene->main_camera);
+        powergl_object_update_mvp(cube, scene->main_camera);
+        powergl_object_update_mvp(&grid, scene->main_camera);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline_render(&scene->pipeline, object_list, count, scene->main_light);
+        scene->main_camera->camera.vp_flag = 0;
+    }
+
+
+    if(frame_counter < max_frames){
+        char fname[64];
+        snprintf(fname, sizeof(fname), "blinnphong_frame_%02d.png", frame_counter);
+        powergl_window_screenshot(fname);
+        frame_counter++;
+    }
+}
+
+int main(){
+    powergl_visualscene scene = {0};
+    setenv("POWERGL_GL_DEBUG", "0", 0);
+    const char *grid_env = getenv("POWERGL_ENABLE_GRID");
+    if(grid_env && strcmp(grid_env, "0") == 0)
+        powergl_enable_grid = 0;
+    scene.create = scene_create;
+    scene.run = scene_run;
+    scene.handle_events = scene_events;
+
+    const char *headless = getenv("POWERGL_HEADLESS");
+    if(headless && strcmp(headless, "1") == 0){
+        powergl_window *wnd =
+            powergl_window_new_with_backend(&scene, &powergl_window_backend_headless);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+        int ret = powergl_window_run(wnd);
+        return ret;
+    } else {
+        powergl_window *wnd = powergl_window_new(&scene);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+
+        nkctx = nk_sdl_init((SDL_Window *)powergl_window_get_native_window(wnd));
+        struct nk_font_atlas *atlas;
+        nk_sdl_font_stash_begin(&atlas);
+        nk_sdl_font_stash_end();
+
+        wnd->root_scene->create(wnd->root_scene);
+
+        SDL_Event e;
+        powergl_event pe;
+        int quit = 0;
+        Uint64 last_counter = SDL_GetPerformanceCounter();
+        Uint64 freq = SDL_GetPerformanceFrequency();
+
+        while(!quit){
+            Uint64 current_counter = SDL_GetPerformanceCounter();
+            float dt = (float)(current_counter - last_counter) / (float)freq;
+
+            nk_input_begin(nkctx);
+            while(SDL_PollEvent(&e)){
+                nk_sdl_handle_event(&e);
+                powergl_sdl_translate_event(&e, &pe);
+                scene.handle_events(&scene, &pe, dt);
+                if(pe.type == POWERGL_EVENT_WINDOW_CLOSE)
+                    quit = 1;
+            }
+            nk_input_end(nkctx);
+
+            scene.run(&scene, dt);
+
+            powergl_ui_draw_scene_hierarchy(nkctx, &scene, nk_rect(10,10,250,400));
+                                           
+            nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
+
+            powergl_window_swap_buffers(wnd);
+            last_counter = current_counter;
+        }
+
+        nk_sdl_shutdown();
+        return 0;
+    }
+}

--- a/tests/flat_demo.c
+++ b/tests/flat_demo.c
@@ -1,0 +1,144 @@
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+#include <string.h>
+#include <stdlib.h>
+#include "src/event.h"
+#include "third_party/nuklear/nuklear.h"
+#include "third_party/nuklear/nuklear_sdl_gl3.h"
+#include "src/window/window.h"
+#include "src/window/headless.h"
+#include "src/rendering/visualscene.h"
+#include "src/rendering/object.h"
+#include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
+#include "src/rendering/pipeline.h"
+#include "src/ui/scene_hierarchy.h"
+#include "src/png/png_loader.h"
+
+#define MAX_VERTEX_MEMORY (512 * 1024)
+#define MAX_ELEMENT_MEMORY (128 * 1024)
+
+static struct nk_context *nkctx;
+
+static powergl_object *cube;
+static powergl_object grid;
+static powergl_object gizmo;
+static powergl_object *object_list[3];
+static int frame_counter = 0;
+static const int max_frames = 1;
+
+static void scene_create(powergl_visualscene *scene){
+    const char *dae = TEST_SRCDIR "/vertexcolored_cube.dae";
+    powergl_scene_build(scene, dae);
+    scene->main_camera = powergl_scene_find(scene, "Camera");
+    if(!scene->main_camera)
+    {
+        scene->main_camera = powergl_camera_default();
+        powergl_scene_add_object(scene, scene->main_camera, NULL);
+    }
+    cube = powergl_scene_find(scene, "Cube");
+    object_list[0] = cube;
+    powergl_grid_create(&grid, 10);
+    object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo);
+    object_list[2] = &gizmo;
+    if(scene->main_camera)
+        scene->main_camera->event_flag = 1;
+    scene->main_light = powergl_scene_find(scene, "Light");
+    powergl_pipeline_flat_create(&scene->pipeline, object_list, 3);
+}
+
+static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
+    powergl_scene_handle_picking(scene, e);
+    if(scene->main_camera)
+        powergl_event_handle(scene->main_camera, e, dt);
+}
+
+static void scene_run(powergl_visualscene *scene, float dt){
+    if(cube && scene->main_camera)
+    {
+        powergl_object_fps_controller(scene->main_camera, dt);
+        powergl_object_update_transform(scene->main_camera, dt);
+        powergl_camera_update(scene->main_camera);
+        powergl_object_update_mvp(cube, scene->main_camera);
+        powergl_object_update_mvp(&grid, scene->main_camera);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline_render(&scene->pipeline, object_list, count, scene->main_light);
+        scene->main_camera->camera.vp_flag = 0;
+    }
+
+
+    if(frame_counter < max_frames){
+        char fname[64];
+        snprintf(fname, sizeof(fname), "flat_frame_%02d.png", frame_counter);
+        powergl_window_screenshot(fname);
+        frame_counter++;
+    }
+}
+
+int main(){
+    powergl_visualscene scene = {0};
+    setenv("POWERGL_GL_DEBUG", "0", 0);
+    const char *grid_env = getenv("POWERGL_ENABLE_GRID");
+    if(grid_env && strcmp(grid_env, "0") == 0)
+        powergl_enable_grid = 0;
+    scene.create = scene_create;
+    scene.run = scene_run;
+    scene.handle_events = scene_events;
+
+    const char *headless = getenv("POWERGL_HEADLESS");
+    if(headless && strcmp(headless, "1") == 0){
+        powergl_window *wnd =
+            powergl_window_new_with_backend(&scene, &powergl_window_backend_headless);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+        int ret = powergl_window_run(wnd);
+        return ret;
+    } else {
+        powergl_window *wnd = powergl_window_new(&scene);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+
+        nkctx = nk_sdl_init((SDL_Window *)powergl_window_get_native_window(wnd));
+        struct nk_font_atlas *atlas;
+        nk_sdl_font_stash_begin(&atlas);
+        nk_sdl_font_stash_end();
+
+        wnd->root_scene->create(wnd->root_scene);
+
+        SDL_Event e;
+        powergl_event pe;
+        int quit = 0;
+        Uint64 last_counter = SDL_GetPerformanceCounter();
+        Uint64 freq = SDL_GetPerformanceFrequency();
+
+        while(!quit){
+            Uint64 current_counter = SDL_GetPerformanceCounter();
+            float dt = (float)(current_counter - last_counter) / (float)freq;
+
+            nk_input_begin(nkctx);
+            while(SDL_PollEvent(&e)){
+                nk_sdl_handle_event(&e);
+                powergl_sdl_translate_event(&e, &pe);
+                scene.handle_events(&scene, &pe, dt);
+                if(pe.type == POWERGL_EVENT_WINDOW_CLOSE)
+                    quit = 1;
+            }
+            nk_input_end(nkctx);
+
+            scene.run(&scene, dt);
+
+            powergl_ui_draw_scene_hierarchy(nkctx, &scene, nk_rect(10,10,250,400));
+                                           
+            nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
+
+            powergl_window_swap_buffers(wnd);
+            last_counter = current_counter;
+        }
+
+        nk_sdl_shutdown();
+        return 0;
+    }
+}

--- a/tests/gouraud_demo.c
+++ b/tests/gouraud_demo.c
@@ -1,0 +1,144 @@
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+#include <string.h>
+#include <stdlib.h>
+#include "src/event.h"
+#include "third_party/nuklear/nuklear.h"
+#include "third_party/nuklear/nuklear_sdl_gl3.h"
+#include "src/window/window.h"
+#include "src/window/headless.h"
+#include "src/rendering/visualscene.h"
+#include "src/rendering/object.h"
+#include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
+#include "src/rendering/pipeline.h"
+#include "src/ui/scene_hierarchy.h"
+#include "src/png/png_loader.h"
+
+#define MAX_VERTEX_MEMORY (512 * 1024)
+#define MAX_ELEMENT_MEMORY (128 * 1024)
+
+static struct nk_context *nkctx;
+
+static powergl_object *cube;
+static powergl_object grid;
+static powergl_object gizmo;
+static powergl_object *object_list[3];
+static int frame_counter = 0;
+static const int max_frames = 1;
+
+static void scene_create(powergl_visualscene *scene){
+    const char *dae = TEST_SRCDIR "/vertexcolored_cube.dae";
+    powergl_scene_build(scene, dae);
+    scene->main_camera = powergl_scene_find(scene, "Camera");
+    if(!scene->main_camera)
+    {
+        scene->main_camera = powergl_camera_default();
+        powergl_scene_add_object(scene, scene->main_camera, NULL);
+    }
+    cube = powergl_scene_find(scene, "Cube");
+    object_list[0] = cube;
+    powergl_grid_create(&grid, 10);
+    object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo);
+    object_list[2] = &gizmo;
+    if(scene->main_camera)
+        scene->main_camera->event_flag = 1;
+    scene->main_light = powergl_scene_find(scene, "Light");
+    powergl_pipeline_gouraud_create(&scene->pipeline, object_list, 3);
+}
+
+static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
+    powergl_scene_handle_picking(scene, e);
+    if(scene->main_camera)
+        powergl_event_handle(scene->main_camera, e, dt);
+}
+
+static void scene_run(powergl_visualscene *scene, float dt){
+    if(cube && scene->main_camera)
+    {
+        powergl_object_fps_controller(scene->main_camera, dt);
+        powergl_object_update_transform(scene->main_camera, dt);
+        powergl_camera_update(scene->main_camera);
+        powergl_object_update_mvp(cube, scene->main_camera);
+        powergl_object_update_mvp(&grid, scene->main_camera);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline_render(&scene->pipeline, object_list, count, scene->main_light);
+        scene->main_camera->camera.vp_flag = 0;
+    }
+
+
+    if(frame_counter < max_frames){
+        char fname[64];
+        snprintf(fname, sizeof(fname), "gouraud_frame_%02d.png", frame_counter);
+        powergl_window_screenshot(fname);
+        frame_counter++;
+    }
+}
+
+int main(){
+    powergl_visualscene scene = {0};
+    setenv("POWERGL_GL_DEBUG", "0", 0);
+    const char *grid_env = getenv("POWERGL_ENABLE_GRID");
+    if(grid_env && strcmp(grid_env, "0") == 0)
+        powergl_enable_grid = 0;
+    scene.create = scene_create;
+    scene.run = scene_run;
+    scene.handle_events = scene_events;
+
+    const char *headless = getenv("POWERGL_HEADLESS");
+    if(headless && strcmp(headless, "1") == 0){
+        powergl_window *wnd =
+            powergl_window_new_with_backend(&scene, &powergl_window_backend_headless);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+        int ret = powergl_window_run(wnd);
+        return ret;
+    } else {
+        powergl_window *wnd = powergl_window_new(&scene);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+
+        nkctx = nk_sdl_init((SDL_Window *)powergl_window_get_native_window(wnd));
+        struct nk_font_atlas *atlas;
+        nk_sdl_font_stash_begin(&atlas);
+        nk_sdl_font_stash_end();
+
+        wnd->root_scene->create(wnd->root_scene);
+
+        SDL_Event e;
+        powergl_event pe;
+        int quit = 0;
+        Uint64 last_counter = SDL_GetPerformanceCounter();
+        Uint64 freq = SDL_GetPerformanceFrequency();
+
+        while(!quit){
+            Uint64 current_counter = SDL_GetPerformanceCounter();
+            float dt = (float)(current_counter - last_counter) / (float)freq;
+
+            nk_input_begin(nkctx);
+            while(SDL_PollEvent(&e)){
+                nk_sdl_handle_event(&e);
+                powergl_sdl_translate_event(&e, &pe);
+                scene.handle_events(&scene, &pe, dt);
+                if(pe.type == POWERGL_EVENT_WINDOW_CLOSE)
+                    quit = 1;
+            }
+            nk_input_end(nkctx);
+
+            scene.run(&scene, dt);
+
+            powergl_ui_draw_scene_hierarchy(nkctx, &scene, nk_rect(10,10,250,400));
+                                           
+            nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
+
+            powergl_window_swap_buffers(wnd);
+            last_counter = current_counter;
+        }
+
+        nk_sdl_shutdown();
+        return 0;
+    }
+}

--- a/tests/lambert_demo.c
+++ b/tests/lambert_demo.c
@@ -1,0 +1,144 @@
+#include <SDL2/SDL.h>
+#include <GL/glew.h>
+#include <SDL2/SDL_opengl.h>
+#include <string.h>
+#include <stdlib.h>
+#include "src/event.h"
+#include "third_party/nuklear/nuklear.h"
+#include "third_party/nuklear/nuklear_sdl_gl3.h"
+#include "src/window/window.h"
+#include "src/window/headless.h"
+#include "src/rendering/visualscene.h"
+#include "src/rendering/object.h"
+#include "src/rendering/grid.h"
+#include "src/rendering/orientation_gizmo.h"
+#include "src/rendering/pipeline.h"
+#include "src/ui/scene_hierarchy.h"
+#include "src/png/png_loader.h"
+
+#define MAX_VERTEX_MEMORY (512 * 1024)
+#define MAX_ELEMENT_MEMORY (128 * 1024)
+
+static struct nk_context *nkctx;
+
+static powergl_object *cube;
+static powergl_object grid;
+static powergl_object gizmo;
+static powergl_object *object_list[3];
+static int frame_counter = 0;
+static const int max_frames = 1;
+
+static void scene_create(powergl_visualscene *scene){
+    const char *dae = TEST_SRCDIR "/vertexcolored_cube.dae";
+    powergl_scene_build(scene, dae);
+    scene->main_camera = powergl_scene_find(scene, "Camera");
+    if(!scene->main_camera)
+    {
+        scene->main_camera = powergl_camera_default();
+        powergl_scene_add_object(scene, scene->main_camera, NULL);
+    }
+    cube = powergl_scene_find(scene, "Cube");
+    object_list[0] = cube;
+    powergl_grid_create(&grid, 10);
+    object_list[1] = &grid;
+    powergl_orientation_gizmo_create(&gizmo);
+    object_list[2] = &gizmo;
+    if(scene->main_camera)
+        scene->main_camera->event_flag = 1;
+    scene->main_light = powergl_scene_find(scene, "Light");
+    powergl_pipeline_lambert_create(&scene->pipeline, object_list, 3);
+}
+
+static void scene_events(powergl_visualscene *scene, powergl_event *e, float dt){
+    powergl_scene_handle_picking(scene, e);
+    if(scene->main_camera)
+        powergl_event_handle(scene->main_camera, e, dt);
+}
+
+static void scene_run(powergl_visualscene *scene, float dt){
+    if(cube && scene->main_camera)
+    {
+        powergl_object_fps_controller(scene->main_camera, dt);
+        powergl_object_update_transform(scene->main_camera, dt);
+        powergl_camera_update(scene->main_camera);
+        powergl_object_update_mvp(cube, scene->main_camera);
+        powergl_object_update_mvp(&grid, scene->main_camera);
+        powergl_orientation_gizmo_update(&gizmo, scene->main_camera);
+        size_t count = powergl_enable_grid ? 3 : 2;
+        powergl_pipeline_render(&scene->pipeline, object_list, count, scene->main_light);
+        scene->main_camera->camera.vp_flag = 0;
+    }
+
+
+    if(frame_counter < max_frames){
+        char fname[64];
+        snprintf(fname, sizeof(fname), "lambert_frame_%02d.png", frame_counter);
+        powergl_window_screenshot(fname);
+        frame_counter++;
+    }
+}
+
+int main(){
+    powergl_visualscene scene = {0};
+    setenv("POWERGL_GL_DEBUG", "0", 0);
+    const char *grid_env = getenv("POWERGL_ENABLE_GRID");
+    if(grid_env && strcmp(grid_env, "0") == 0)
+        powergl_enable_grid = 0;
+    scene.create = scene_create;
+    scene.run = scene_run;
+    scene.handle_events = scene_events;
+
+    const char *headless = getenv("POWERGL_HEADLESS");
+    if(headless && strcmp(headless, "1") == 0){
+        powergl_window *wnd =
+            powergl_window_new_with_backend(&scene, &powergl_window_backend_headless);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+        int ret = powergl_window_run(wnd);
+        return ret;
+    } else {
+        powergl_window *wnd = powergl_window_new(&scene);
+        if(!powergl_window_create(wnd, 640, 480))
+            return 1;
+
+        nkctx = nk_sdl_init((SDL_Window *)powergl_window_get_native_window(wnd));
+        struct nk_font_atlas *atlas;
+        nk_sdl_font_stash_begin(&atlas);
+        nk_sdl_font_stash_end();
+
+        wnd->root_scene->create(wnd->root_scene);
+
+        SDL_Event e;
+        powergl_event pe;
+        int quit = 0;
+        Uint64 last_counter = SDL_GetPerformanceCounter();
+        Uint64 freq = SDL_GetPerformanceFrequency();
+
+        while(!quit){
+            Uint64 current_counter = SDL_GetPerformanceCounter();
+            float dt = (float)(current_counter - last_counter) / (float)freq;
+
+            nk_input_begin(nkctx);
+            while(SDL_PollEvent(&e)){
+                nk_sdl_handle_event(&e);
+                powergl_sdl_translate_event(&e, &pe);
+                scene.handle_events(&scene, &pe, dt);
+                if(pe.type == POWERGL_EVENT_WINDOW_CLOSE)
+                    quit = 1;
+            }
+            nk_input_end(nkctx);
+
+            scene.run(&scene, dt);
+
+            powergl_ui_draw_scene_hierarchy(nkctx, &scene, nk_rect(10,10,250,400));
+                                           
+            nk_sdl_render(NK_ANTI_ALIASING_OFF, MAX_VERTEX_MEMORY, MAX_ELEMENT_MEMORY);
+
+            powergl_window_swap_buffers(wnd);
+            last_counter = current_counter;
+        }
+
+        nk_sdl_shutdown();
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add flat, gouraud, lambert and blinn-phong demo programs
- implement new pipeline creation helpers for shading techniques
- expose new APIs in `pipeline.h`
- build demos in autotools and CMake

## Testing
- `autoreconf -i`
- `./configure`
- `make -j$(nproc) check`

------
https://chatgpt.com/codex/tasks/task_e_68750ecd1a148322b972138f23c630a3