### PR TITLE
Fix distcheck with shading demo PNGs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,10 +58,13 @@ distclean-local: code-coverage-dist-clean
 
 # Test data files shipped with the distribution
 EXTRA_DIST = vertexcolored_cube.dae vertexcoloredcube_demo.png \
+    blinnphongshadedcube.png gouraudshadedcube.png lambertshadedcube.png \
     run_vertexcoloredcube_headless.sh run_flatshadedcube_headless.sh \
-    run_gouraudshadedcube_headless.sh run_lambertshadedcube_headless.sh run_blinnphongshadedcube_headless.sh
+    run_gouraudshadedcube_headless.sh run_lambertshadedcube_headless.sh \
+    run_blinnphongshadedcube_headless.sh
 
 # Remove generated files produced during tests
-CLEANFILES = cube_exported.dae exported.dae frame_*.png
+CLEANFILES = cube_exported.dae exported.dae frame_*.png flat_frame_*.png \
+    gouraud_frame_*.png lambert_frame_*.png blinnphong_frame_*.png
 
 # Run tests via make check


### PR DESCRIPTION
## Summary
- include reference PNGs for shading demos in `EXTRA_DIST`
- clean up generated screenshot files

## Testing
- `autoreconf -fi`
- `./configure`
- `make distcheck`

------
https://chatgpt.com/codex/tasks/task_e_6879f7914bfc83229a49929e50f90c82