### PR TITLE
Fix flat shading by generating per-face normals

### DIFF
--- a/src/rendering/object.c
+++ b/src/rendering/object.c
@@ -566,6 +566,47 @@ void powergl_object_geometry_reset(powergl_geometry *geo){
 
 }
 
+void powergl_geometry_generate_flat_normals(powergl_geometry *geo){
+  if(geo->n_vertex == 0 || geo->n_vertex % 3 != 0){
+    return;
+  }
+
+  if(geo->triangles.normal){
+    free(geo->triangles.normal);
+  }
+
+  geo->triangles.normal = powergl_resize(NULL, geo->n_vertex, sizeof(powergl_vec3));
+  geo->triangles.n_normal = geo->n_vertex;
+
+  for(size_t i = 0; i < geo->n_vertex; i += 3){
+    powergl_vec3 v0 = geo->vertex[i];
+    powergl_vec3 v1 = geo->vertex[i+1];
+    powergl_vec3 v2 = geo->vertex[i+2];
+    powergl_vec3 e1 = powergl_vec3_sub(v1, v0);
+    powergl_vec3 e2 = powergl_vec3_sub(v2, v0);
+    powergl_vec3 n = powergl_vec3_norm(powergl_vec3_cross(e1, e2));
+    geo->triangles.normal[i] = n;
+    geo->triangles.normal[i+1] = n;
+    geo->triangles.normal[i+2] = n;
+  }
+
+  geo->triangles.normal_flag = 1;
+}
+
+static void object_generate_flat_normals_rec(powergl_object *obj){
+  if(obj->geometry.visible_flag && obj->geometry.n_vertex > 0){
+    powergl_geometry_generate_flat_normals(&obj->geometry);
+  }
+
+  for(size_t i = 0; i < obj->n_object; ++i){
+    object_generate_flat_normals_rec(obj->objects[i]);
+  }
+}
+
+void powergl_object_generate_flat_normals(powergl_object *obj){
+  object_generate_flat_normals_rec(obj);
+}
+
 powergl_object *powergl_camera_default(){
   powergl_object *cam = powergl_resize(NULL, 1, sizeof(powergl_object));
   memset(cam, 0, sizeof(powergl_object));

--- a/src/rendering/object.h
+++ b/src/rendering/object.h
@@ -247,6 +247,12 @@ void powergl_event_handle(powergl_object *obj, powergl_event *e, float delta_tim
 void powergl_object_geometry_append(powergl_geometry *dest, powergl_geometry *src, powergl_vec3 offset, powergl_vec3 color);
 void powergl_object_geometry_reset(powergl_geometry *geo);
 
+/* Generate per-face normals for flat shading. The normal array will be resized
+   so that each vertex has the face normal of its triangle. */
+void powergl_geometry_generate_flat_normals(powergl_geometry *geo);
+/* Recursively generate flat normals for the given object and all children. */
+void powergl_object_generate_flat_normals(powergl_object *obj);
+
 void powergl_transform_reset(powergl_transform *trans);
 
 /* Creates and returns a camera object with default parameters.

--- a/src/rendering/pipeline.c
+++ b/src/rendering/pipeline.c
@@ -771,6 +771,10 @@ void powergl_pipeline_flat_create(powergl_pipeline *ppl, powergl_object **objs, 
   ppl->uni_light_dir = glGetUniformLocation(ppl->gp, "lightDir");
   ppl->uni_sampler = -1;
 
+  for(size_t i = 0; i < n_obj; ++i){
+    powergl_object_generate_flat_normals(objs[i]);
+  }
+
   powergl_pipeline_create_objects(ppl, objs, n_obj);
 }
 


### PR DESCRIPTION
## Summary
- compute per-face normals and propagate recursively
- generate flat normals during pipeline setup

## Testing
- `autoreconf -i`
- `./configure`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687978aad74c8322ab221fd85c63eb19