### PR TITLE
Add tests for UV failure cases in ray triangle intersection

### DIFF
--- a/tests/gtest_intersect.cpp
+++ b/tests/gtest_intersect.cpp
@@ -34,6 +34,34 @@ TEST(Intersect, CullBackface){
     ASSERT_EQ(hit, 0);
 }
 
+TEST(Intersect, CullUTestFail){
+    powergl_vec3 mesh[3] = {
+        { 1.0f, -1.0f, 0.0f},
+        {-1.0f, -1.0f, 0.0f},
+        { 0.0f,  1.0f, 0.0f}
+    };
+    powergl_mat4 mvp = powergl_mat4_ident();
+    powergl_vec2 event = {80.0f, 50.0f};
+    powergl_vec4 vp = {0.0f, 0.0f, 100.0f, 100.0f};
+    powergl_vec3 out;
+    int hit = powergl_intersect_ray_tri_mesh(mesh, 3, mvp, event, vp, &out, 1);
+    ASSERT_EQ(hit, 0);
+}
+
+TEST(Intersect, CullVTestFail){
+    powergl_vec3 mesh[3] = {
+        { 1.0f, -1.0f, 0.0f},
+        {-1.0f, -1.0f, 0.0f},
+        { 0.0f,  1.0f, 0.0f}
+    };
+    powergl_mat4 mvp = powergl_mat4_ident();
+    powergl_vec2 event = {30.0f, 10.0f};
+    powergl_vec4 vp = {0.0f, 0.0f, 100.0f, 100.0f};
+    powergl_vec3 out;
+    int hit = powergl_intersect_ray_tri_mesh(mesh, 3, mvp, event, vp, &out, 1);
+    ASSERT_EQ(hit, 0);
+}
+
 int main(int argc, char **argv){
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary
- expand `gtest_intersect.cpp` with UV failure scenarios

## Testing
- `make -j$(nproc)`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68751024a3788322ac9d27e732d6e92c